### PR TITLE
feat(ai-ide): enforce a size limit in the whole-file write tools

### DIFF
--- a/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
@@ -47,6 +47,7 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { ChangeSetElementArgs, ChangeSetFileElementFactory, ChangeSetFileElement } from '@theia/ai-chat/lib/browser/change-set-file-element';
 import { URI } from '@theia/core/lib/common/uri';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { WRITE_CONTENT_MAX_SIZE_KB_PREF } from '../common/workspace-preferences';
 
 disableJSDOM();
 
@@ -54,6 +55,8 @@ describe('File Changeset Functions Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
     let mockCtx: ChatToolContext;
     let container: Container;
+    let preferenceValues: Record<string, unknown>;
+    let createdElements: ChangeSetElementArgs[];
     before(() => {
         disableJSDOM = enableJSDOM();
     });
@@ -63,6 +66,8 @@ describe('File Changeset Functions Cancellation Tests', () => {
     });
     beforeEach(() => {
         cancellationTokenSource = new CancellationTokenSource();
+        preferenceValues = {};
+        createdElements = [];
 
         // Create a mock change set that doesn't do anything
         const mockChangeSet: Partial<ChangeSet> = {
@@ -99,17 +104,23 @@ describe('File Changeset Functions Cancellation Tests', () => {
             read: async () => ({ value: { toString: () => 'test content' } })
         } as unknown as FileService;
 
-        const mockFileChangeFactory: ChangeSetFileElementFactory = () => ({
-            uri: new URI('file:///workspace/test.txt'),
-            type: 'modify',
-            state: 'pending',
-            targetState: 'new content',
-            apply: async () => { },
-        } as ChangeSetFileElement);
+        const mockFileChangeFactory: ChangeSetFileElementFactory = (elementArgs: ChangeSetElementArgs) => {
+            createdElements.push(elementArgs);
+            return {
+                uri: new URI('file:///workspace/test.txt'),
+                type: 'modify',
+                state: 'pending',
+                targetState: 'new content',
+                apply: async () => { },
+            } as ChangeSetFileElement;
+        };
 
         // Register mocks in the container
         container.bind(WorkspaceFunctionScope).toConstantValue(mockWorkspaceScope);
         container.bind(ILogger).to(MockLogger).inSingletonScope();
+        container.bind(PreferenceService).toConstantValue({
+            get: <T>(preferenceName: string, defaultValue: T) => (preferenceValues[preferenceName] ?? defaultValue) as T
+        } as unknown as PreferenceService);
         container.bind(FileService).toConstantValue(mockFileService);
         container.bind(ChangeSetFileElementFactory).toConstantValue(mockFileChangeFactory);
         container.bind(FileChangeSetTitleProvider).to(DefaultFileChangeSetTitleProvider).inSingletonScope();
@@ -313,6 +324,53 @@ describe('File Changeset Functions Cancellation Tests', () => {
 
             const result = await handler(JSON.stringify({ path: 'test.txt', content: 'new content' }), mockCtx);
             expect(result).to.equal('Successfully wrote content to file test.txt.');
+        });
+    });
+
+    describe('write content size guard', () => {
+        it('WriteFileContent rejects content exceeding the maximum write size', async () => {
+            preferenceValues[WRITE_CONTENT_MAX_SIZE_KB_PREF] = 1;
+            const handler = container.get(WriteFileContent).getTool().handler;
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: 'x'.repeat(2048) }), mockCtx);
+
+            const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
+            expect(jsonResponse.error).to.match(/maximum write size/);
+            expect(jsonResponse.error).to.include('writeFileReplacements');
+            expect(createdElements).to.be.empty;
+        });
+
+        it('SuggestFileContent rejects content exceeding the maximum write size', async () => {
+            preferenceValues[WRITE_CONTENT_MAX_SIZE_KB_PREF] = 1;
+            const handler = container.get(SuggestFileContent).getTool().handler;
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: 'x'.repeat(2048) }), mockCtx);
+
+            const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
+            expect(jsonResponse.error).to.match(/maximum write size/);
+            expect(jsonResponse.error).to.include('suggestFileReplacements');
+            expect(createdElements).to.be.empty;
+        });
+
+        it('WriteFileContent accepts content within the limit', async () => {
+            preferenceValues[WRITE_CONTENT_MAX_SIZE_KB_PREF] = 1;
+            const handler = container.get(WriteFileContent).getTool().handler;
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: 'small content' }), mockCtx);
+
+            expect(result).to.equal('Successfully wrote content to file test.txt.');
+            expect(createdElements).to.have.length(1);
+        });
+
+        it('WriteFileContent still allows deleting a file (empty content)', async () => {
+            preferenceValues[WRITE_CONTENT_MAX_SIZE_KB_PREF] = 1;
+            const handler = container.get(WriteFileContent).getTool().handler;
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: '' }), mockCtx);
+
+            expect(result).to.equal('Successfully wrote content to file test.txt.');
+            expect(createdElements).to.have.length(1);
+            expect(createdElements[0].type).to.equal('delete');
         });
     });
 });

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -24,7 +24,7 @@ import { inject, injectable, named, optional } from '@theia/core/shared/inversif
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceFunctionScope } from './workspace-functions';
 
-import { nls, ILogger } from '@theia/core';
+import { nls, ILogger, PreferenceService } from '@theia/core';
 import { extractJsonStringField } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/toolcall-utils';
 import {
     CLEAR_FILE_CHANGES_ID,
@@ -36,6 +36,7 @@ import {
     SUGGEST_FILE_REPLACEMENTS_SIMPLE_ID,
     WRITE_FILE_REPLACEMENTS_SIMPLE_ID
 } from '../common/file-changeset-function-ids';
+import { WRITE_CONTENT_MAX_SIZE_KB_PREF } from '../common/workspace-preferences';
 
 /**
  * Description of the `path` parameter shared by all file changeset tools, so that they advertise the
@@ -60,6 +61,16 @@ function createPathShortLabel(args: string, hasMore: boolean): { label: string; 
  */
 function staleFileError(path: string): string {
     return `File ${path} changed since you last read it. Read it again before overwriting it, so that the changes made in the meantime are not lost.`;
+}
+
+/**
+ * Whole-file writes require the model to re-emit the entire content as tool arguments, so their cost grows
+ * with file size; mirror the read-side limit and steer oversized writes to the replacement-based tools.
+ */
+function writeContentSizeError(sizeKB: number, maxSizeKB: number, replacementsToolId: string): string {
+    return `The provided content is ${sizeKB}KB, but the maximum write size is ${maxSizeKB}KB ` +
+        `(preference "${WRITE_CONTENT_MAX_SIZE_KB_PREF}"). Use ${replacementsToolId} for targeted edits, ` +
+        'or avoid embedding large data in the file and reference it by path instead.';
 }
 
 export const FileChangeSetTitleProvider = Symbol('FileChangeSetTitleProvider');
@@ -88,6 +99,9 @@ export class SuggestFileContent implements ToolProvider {
     @inject(FileReadTracker) @optional()
     protected readonly fileReadTracker: FileReadTracker | undefined;
 
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
     getTool(): ToolRequest {
         return {
             id: SuggestFileContent.ID,
@@ -97,7 +111,8 @@ export class SuggestFileContent implements ToolProvider {
              If the new content is empty, the file will be deleted. To move a file, delete it and re-create it at the new location.
              The proposed changes will be applied when the user accepts. If called again for the same file, previously proposed changes will be overridden.
              Use this for creating new files or when you need to rewrite an entire file.
-             For targeted edits to existing files, prefer suggestFileReplacements instead - it's more efficient and shows clearer diffs.`,
+             For targeted edits to existing files, prefer suggestFileReplacements instead - it's more efficient and shows clearer diffs.
+             Content exceeding the configured maximum write size is rejected.`,
             parameters: {
                 type: 'object',
                 properties: {
@@ -119,6 +134,11 @@ export class SuggestFileContent implements ToolProvider {
                     return JSON.stringify({ error: 'Operation cancelled by user' });
                 }
                 const { path, content } = JSON.parse(args);
+                const maxWriteSizeKB = this.preferenceService.get<number>(WRITE_CONTENT_MAX_SIZE_KB_PREF, 256);
+                const contentSizeKB = Math.round(Buffer.byteLength(content, 'utf8') / 1024);
+                if (contentSizeKB > maxWriteSizeKB) {
+                    return JSON.stringify({ error: writeContentSizeError(contentSizeKB, maxWriteSizeKB, SUGGEST_FILE_REPLACEMENTS_ID) });
+                }
                 const chatSessionId = ctx.request.session.id;
                 let uri: URI;
                 try {
@@ -175,6 +195,9 @@ export class WriteFileContent implements ToolProvider {
     @inject(FileReadTracker) @optional()
     protected readonly fileReadTracker: FileReadTracker | undefined;
 
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
     getTool(): ToolRequest {
         return {
             id: WriteFileContent.ID,
@@ -184,6 +207,7 @@ export class WriteFileContent implements ToolProvider {
              If the new content is empty, the file will be deleted. To move a file, delete it and re-create it at the new location.
              Use this for creating new files or complete file rewrites in agent mode.
              For targeted edits, prefer writeFileReplacements - it's more efficient and less error-prone.
+             Content exceeding the configured maximum write size is rejected.
              CAUTION: Changes are applied immediately and cannot be undone through the chat interface.`,
             parameters: {
                 type: 'object',
@@ -206,6 +230,11 @@ export class WriteFileContent implements ToolProvider {
                     return JSON.stringify({ error: 'Operation cancelled by user' });
                 }
                 const { path, content } = JSON.parse(args);
+                const maxWriteSizeKB = this.preferenceService.get<number>(WRITE_CONTENT_MAX_SIZE_KB_PREF, 256);
+                const contentSizeKB = Math.round(Buffer.byteLength(content, 'utf8') / 1024);
+                if (contentSizeKB > maxWriteSizeKB) {
+                    return JSON.stringify({ error: writeContentSizeError(contentSizeKB, maxWriteSizeKB, WRITE_FILE_REPLACEMENTS_ID) });
+                }
                 const chatSessionId = ctx.request.session.id;
                 let uri: URI;
                 try {

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -24,6 +24,7 @@ export const PROMPT_TEMPLATE_ADDITIONAL_EXTENSIONS_PREF = 'ai-features.promptTem
 export const PROMPT_TEMPLATE_WORKSPACE_FILES_PREF = 'ai-features.promptTemplates.WorkspaceTemplateFiles';
 export const TASK_CONTEXT_STORAGE_DIRECTORY_PREF = 'ai-features.promptTemplates.taskContextStorageDirectory';
 export const FILE_CONTENT_MAX_SIZE_KB_PREF = 'ai-features.workspaceFunctions.fileContentMaxSizeKB';
+export const WRITE_CONTENT_MAX_SIZE_KB_PREF = 'ai-features.workspaceFunctions.writeContentMaxSizeKB';
 export const ALLOWED_EXTERNAL_PATHS_PREF = 'ai-features.workspaceFunctions.allowedExternalPaths';
 
 const CONFLICT_RESOLUTION_DESCRIPTION = 'When templates with the same ID (filename) exist in multiple locations, conflicts are resolved by priority: specific template files \
@@ -101,6 +102,15 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
                 'Maximum size in kilobytes of the content returned by the getFileContent tool. ' +
                 'When reading a full file (no offset/limit), files exceeding this limit return an error. ' +
                 'When using offset and limit, only the requested range is checked against this limit.'),
+            default: 256,
+            minimum: 1
+        },
+        [WRITE_CONTENT_MAX_SIZE_KB_PREF]: {
+            type: 'number',
+            title: nls.localize('theia/ai/workspace/writeContentMaxSizeKB/title', 'Write Content Max Size (KB)'),
+            description: nls.localize('theia/ai/workspace/writeContentMaxSizeKB/description',
+                'Maximum size in kilobytes of the content accepted by the whole-file write tools (writeFileContent and suggestFileContent). ' +
+                'Larger writes are rejected with a hint to use the replacement-based tools instead.'),
             default: 256,
             minimum: 1
         },


### PR DESCRIPTION
#### What it does

Fixes #17973.

`getFileContent` caps its result at `ai-features.workspaceFunctions.fileContentMaxSizeKB` (default 256 KB), but the whole-file write tools accepted content of any size — even though they require the model to re-emit the entire file as tool-call arguments, which for large payloads (e.g. base64-embedded binaries) takes many minutes or exceeds the model's max output tokens.

- New preference `ai-features.workspaceFunctions.writeContentMaxSizeKB` (default 256 KB, mirroring the read side).
- `writeFileContent` and `suggestFileContent` reject larger content with an error naming the preference and steering the model to the replacement-based tools (`writeFileReplacements` / `suggestFileReplacements`) or to referencing large data by path instead of embedding it.
- Deleting a file (empty content) is unaffected; the replacement-based tools are unaffected.
- Tool descriptions mention the limit so agents can plan around it.

#### How to test

1. `cd packages/ai-ide && npx mocha --config ../../configs/mocharc.yml "./lib/**/*.spec.js"` — 451 passing, including 4 new tests for the guard.
2. In an AI chat, ask the agent to write a file larger than the limit via `writeFileContent` — the call returns the size error immediately instead of streaming the whole payload; lowering the preference (e.g. to 1) makes this easy to trigger with small files.

#### Follow-ups

The broader inefficiencies with huge single-line content (Monaco model cost, argument retention) noted in #17973 are not addressed here.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
