### PR TITLE
fix(plugin-ext): save editors that are not text editors

### DIFF
--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.spec.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.spec.ts
@@ -1,0 +1,140 @@
+// *****************************************************************************
+// Copyright (C) 2026 JuliaHub, Inc. and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { Emitter, URI } from '@theia/core';
+import { BaseWidget, Navigatable, Saveable, SaveableSource, Widget } from '@theia/core/lib/browser';
+import { SaveableService } from '@theia/core/lib/browser/saveable-service';
+import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
+import { EditorsAndDocumentsMain } from './editors-and-documents-main';
+
+disableJSDOM();
+
+class TestSaveable implements Saveable {
+    dirty = true;
+    readonly onDirtyChanged = new Emitter<void>().event;
+    readonly onContentChanged = new Emitter<void>().event;
+    saveCount = 0;
+
+    async save(): Promise<void> {
+        this.saveCount++;
+        this.dirty = false;
+    }
+}
+
+/** Navigatable to the resource, but with nothing to save. */
+class TestNavigatableWidget extends BaseWidget implements Navigatable {
+    constructor(private readonly uri: URI) {
+        super();
+    }
+
+    getResourceUri(): URI {
+        return this.uri;
+    }
+
+    createMoveToUri(): URI {
+        return this.uri;
+    }
+}
+
+/** Stands in for a `CustomEditorWidget`: saveable and navigatable, but not an `EditorWidget`. */
+class TestSaveableWidget extends TestNavigatableWidget implements SaveableSource {
+    readonly saveable = new TestSaveable();
+}
+
+function createEditorsAndDocumentsMain(
+    editor: EditorWidget | undefined,
+    widgets: Widget[]
+): EditorsAndDocumentsMain {
+    // Bypass the constructor's RPC/container wiring: `save` and `saveAs` only touch the
+    // editor manager, the shell and the saveable service.
+    const main = Object.create(EditorsAndDocumentsMain.prototype) as EditorsAndDocumentsMain;
+    const fields = main as unknown as Record<string, unknown>;
+    fields.editorManager = { getByUri: async () => editor } as unknown as EditorManager;
+    fields.shell = { widgets };
+    fields.saveResourceService = new SaveableService();
+    return main;
+}
+
+describe('EditorsAndDocumentsMain#save', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    const uri = new URI('custom-editor:/some/resource?viewType=test');
+
+    it('saves a saveable widget that the editor manager does not know', async () => {
+        const widget = new TestSaveableWidget(uri);
+        const main = createEditorsAndDocumentsMain(undefined, [widget]);
+
+        const saved = await main.save(uri);
+
+        expect(widget.saveable.saveCount).to.equal(1);
+        expect(saved?.toString()).to.equal(uri.toString());
+    });
+
+    it('prefers the text editor when the editor manager has one', async () => {
+        const editor = new TestSaveableWidget(uri);
+        const custom = new TestSaveableWidget(uri);
+        const main = createEditorsAndDocumentsMain(editor as unknown as EditorWidget, [custom]);
+
+        await main.save(uri);
+
+        expect(editor.saveable.saveCount).to.equal(1);
+        expect(custom.saveable.saveCount).to.equal(0);
+    });
+
+    it('leaves widgets bound to another resource alone', async () => {
+        const other = new TestSaveableWidget(new URI('custom-editor:/other/resource'));
+        const main = createEditorsAndDocumentsMain(undefined, [other]);
+
+        const saved = await main.save(uri);
+
+        expect(other.saveable.saveCount).to.equal(0);
+        expect(saved).to.be.undefined;
+    });
+
+    it('ignores a widget that is navigatable to the resource but not saveable', async () => {
+        const main = createEditorsAndDocumentsMain(undefined, [new TestNavigatableWidget(uri)]);
+
+        expect(await main.save(uri)).to.be.undefined;
+    });
+
+    it('resolves saveAs through the same fallback', async () => {
+        const widget = new TestSaveableWidget(uri);
+        const main = createEditorsAndDocumentsMain(undefined, [widget]);
+        const saveAsTargets: Widget[] = [];
+        // `SaveableService.canSaveAs` is unconditionally false on the base class, so the
+        // service is stubbed to reach the `saveAs` branch at all.
+        (main as unknown as Record<string, unknown>).saveResourceService = {
+            canSaveAs: (candidate: Widget) => candidate === widget,
+            saveAs: async (target: Widget) => { saveAsTargets.push(target); return uri; }
+        };
+
+        const saved = await main.saveAs(uri);
+
+        expect(saveAsTargets).to.deep.equal([widget]);
+        expect(saved?.toString()).to.equal(uri.toString());
+    });
+});

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -33,6 +33,7 @@ import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { TextEditorMain } from './text-editor-main';
 import { DisposableCollection, Emitter, URI } from '@theia/core';
 import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
+import { ApplicationShell, NavigatableWidget, Saveable, Widget } from '@theia/core/lib/browser';
 import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 import { TabsMainImpl } from './tabs/tabs-main';
 import { NotebookCellEditorService, NotebookEditorWidgetService } from '@theia/notebook/lib/browser';
@@ -48,6 +49,7 @@ export class EditorsAndDocumentsMain implements Disposable {
 
     private readonly modelService: EditorModelService;
     private readonly editorManager: EditorManager;
+    private readonly shell: ApplicationShell;
     private readonly saveResourceService: SaveableService;
     private readonly encodingRegistry: EncodingRegistry;
 
@@ -69,6 +71,7 @@ export class EditorsAndDocumentsMain implements Disposable {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT);
 
         this.editorManager = container.get(EditorManager);
+        this.shell = container.get(ApplicationShell);
         this.modelService = container.get(EditorModelService);
         this.saveResourceService = container.get(SaveableService);
         this.encodingRegistry = container.get(EncodingRegistry);
@@ -183,22 +186,31 @@ export class EditorsAndDocumentsMain implements Disposable {
     }
 
     async save(uri: URI): Promise<URI | undefined> {
-        const editor = await this.editorManager.getByUri(uri);
-        if (!editor) {
+        const widget = await this.getSaveTarget(uri);
+        if (!widget) {
             return undefined;
         }
-        return this.saveResourceService.save(editor);
+        return this.saveResourceService.save(widget);
     }
 
     async saveAs(uri: URI): Promise<URI | undefined> {
-        const editor = await this.editorManager.getByUri(uri);
-        if (!editor) {
+        const widget = await this.getSaveTarget(uri);
+        if (!widget) {
             return undefined;
         }
-        if (!this.saveResourceService.canSaveAs(editor)) {
+        if (!this.saveResourceService.canSaveAs(widget)) {
             return undefined;
         }
-        return this.saveResourceService.saveAs(editor);
+        return this.saveResourceService.saveAs(widget);
+    }
+
+    /**
+     * Resolve the widget holding `uri`, preferring a text editor. Custom editors and notebooks
+     * are not opened by the `EditorManager`, so they are only reachable through the shell.
+     */
+    protected async getSaveTarget(uri: URI): Promise<Widget | undefined> {
+        return await this.editorManager.getByUri(uri)
+            ?? this.shell.widgets.find(widget => Saveable.get(widget) && NavigatableWidget.getUri(widget)?.isEqual(uri));
     }
 
     saveAll(includeUntitled?: boolean): Promise<boolean> {


### PR DESCRIPTION
#### What it does

`workspace.save` and `workspace.saveAs` resolve their target through `EditorManager.getByUri`, which only knows widgets opened by the `code-editor-opener`. A custom editor or a notebook is opened by a different handler, so the lookup returns `undefined` and both API calls resolve to `undefined` having saved nothing — and without throwing, so a caller that ignores the return value sees no sign that anything went wrong.

VS Code resolves any editor input for the resource, custom editors included. That difference is load-bearing for extensions: a `CustomEditorProvider` whose document mirrors a text file has no other way to reconcile its dirty state when the file is saved elsewhere. There is no API to clear a custom document's dirty flag directly, so the sanctioned move is to listen for `onDidSaveTextDocument` and call `workspace.save` on the custom document's URI, expecting `saveCustomDocument` to run. On Theia that call is a silent no-op, and the custom editor keeps its dirty indicator until the user saves that tab too.

This resolves the target through `getSaveTarget`, which still prefers a text editor and falls back to any saveable, navigatable widget in the shell bound to the same resource. Where a text editor exists the behavior is unchanged; the fallback only fires where the method previously returned `undefined`. `NotebookEditorWidget` is `Navigatable, SaveableSource` and equally unknown to the `EditorManager`, so notebooks are fixed by the same lookup.

#### How to test

`EditorsAndDocumentsMain#save` in `packages/plugin-ext/src/main/browser/editors-and-documents-main.spec.ts` covers the lookup directly. Two of its cases fail on `master` — the fallback is never consulted, so the widget's `save` is never called — and pass with this change.

For a manual check, an extension registering a `CustomEditorProvider` on a virtual URI can call `vscode.workspace.save(document.uri)` while that editor is dirty. Before: the call resolves to `undefined` and `saveCustomDocument` is never invoked. After: the provider is asked to save and the tab's dirty indicator clears.

#### Follow-ups

`saveAll` delegates to `EditorModelService.saveAll`, which iterates only the Monaco text models, so `workspace.saveAll` still skips a dirty custom editor or notebook — the same blind spot this change fixes for `save`. It is left out here because it needs a different lookup shape, every dirty saveable rather than one URI, and a decision about what the boolean result should mean when one of them fails.

Is that worth an issue and a follow-up PR, or is the current `saveAll` behavior intentional? I am happy to open both if there is interest.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
