### PR TITLE
Fix/ai first perspective chat left panel

### DIFF
--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -36,12 +36,15 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
             id: AI_FIRST_PERSPECTIVE_ID,
             label: nls.localize('theia/ai-ide/perspective/aiFirst', 'AI First'),
             viewPlacements: new Map<string, ApplicationShell.Area>([
-                [ChatViewWidget.ID, 'main'],
+                [ChatViewWidget.ID, 'left'],
+                [AISessionsWidget.ID, 'left'],
                 [EXPLORER_VIEW_CONTAINER_ID, 'right'],
-                [SCM_VIEW_CONTAINER_ID, 'right'],
-                [AISessionsWidget.ID, 'left']
+                [SCM_VIEW_CONTAINER_ID, 'right']
             ]),
-            primaryViews: { right: EXPLORER_VIEW_CONTAINER_ID },
+            primaryViews: {
+                left: ChatViewWidget.ID,
+                right: EXPLORER_VIEW_CONTAINER_ID
+            },
             chromeOptions
         });
     }


### PR DESCRIPTION
#### What it does

Editors and chat previously shared the `main` stack in the AI First perspective, making it hard to view a file while chatting or use `#editorContext`/`#file` references. This PR moves `ChatViewWidget` from `main` to `left`, alongside `AISessionsWidget`, and sets it as the primary view for that area. Editors now have the `main` area entirely to themselves, and open to the right of chat as requested in the issue.

Fixes #17888

#### How to test

1. Switch to the AI First perspective.
2. Open any file from the explorer.
3. Confirm the editor opens in the main area, not stacked with the chat view.
4. Confirm chat remains visible and usable in the left panel alongside AI Sessions.
5. Try referencing an open file from chat (e.g. `#editorContext` / `#file`) and confirm it works as expected while the editor is visible.

#### Follow-ups

None identified at this time.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

N/A

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)