### PR TITLE
fix(ai-config): agent detail select font and truncated tool descriptions

### DIFF
--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-components.spec.ts
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-components.spec.ts
@@ -203,6 +203,64 @@ describe('AI Configuration primitives', () => {
         host.remove();
     });
 
+    /**
+     * JSDOM lays nothing out, so every element reports a zero height and a description would never measure as
+     * clamped. Fakes the two heights the row compares, which is exactly the browser's "the text does not fit"
+     * signal, and restores them afterwards.
+     */
+    function withClampedText(scrollHeight: number, run: () => void): void {
+        // Both live on `Element.prototype`, which is where JSDOM defines them.
+        const prototype = document.defaultView!.Element.prototype;
+        const original = {
+            scrollHeight: Object.getOwnPropertyDescriptor(prototype, 'scrollHeight')!,
+            clientHeight: Object.getOwnPropertyDescriptor(prototype, 'clientHeight')!
+        };
+        Object.defineProperty(prototype, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+        Object.defineProperty(prototype, 'clientHeight', { configurable: true, get: () => 40 });
+        try {
+            run();
+        } finally {
+            Object.defineProperty(prototype, 'scrollHeight', original.scrollHeight);
+            Object.defineProperty(prototype, 'clientHeight', original.clientHeight);
+        }
+    }
+
+    it('AiConfigurationItemRow expands a description that does not fit, and leaves a fitting one alone', () => {
+        // A tool description running past the two-line clamp is otherwise unreadable in the list.
+        withClampedText(120, () => {
+            let rowOpened = 0;
+            const { container, dispose } = mount(React.createElement(AiConfigurationItemRow, {
+                label: 'writeFileReplacements',
+                description: 'Replace text in a file. The old text must be unique in the file.',
+                onSelect: () => { rowOpened++; }
+            }));
+            try {
+                const description = container.querySelector('.ai-configuration-item-row-description') as HTMLElement;
+                expect(description.classList.contains('expanded')).to.equal(false);
+                const toggle = container.querySelector('.ai-configuration-item-row-description-toggle') as HTMLButtonElement;
+                expect(Boolean(toggle)).to.equal(true);
+                expect(toggle.getAttribute('aria-expanded')).to.equal('false');
+
+                flushSync(() => toggle.click());
+                expect(description.classList.contains('expanded')).to.equal(true);
+                expect(container.querySelector('.ai-configuration-item-row-description-toggle')!.getAttribute('aria-expanded')).to.equal('true');
+                // Reading the description must not also open the row's detail page.
+                expect(rowOpened).to.equal(0);
+            } finally {
+                dispose();
+            }
+        });
+        // Nothing hidden, so no toggle to offer.
+        withClampedText(40, () => {
+            const { container, dispose } = mount(React.createElement(AiConfigurationItemRow, { label: 'readFile', description: 'Read a file.' }));
+            try {
+                expect(Boolean(container.querySelector('.ai-configuration-item-row-description-toggle'))).to.equal(false);
+            } finally {
+                dispose();
+            }
+        });
+    });
+
     it('AiConfigurationEmptyState renders the message and an optional action', async () => {
         const tree = await AiConfigurationEmptyState({ message: 'Nothing here', action: React.createElement('button', {}, 'Add') });
         expect(textOf(tree)).to.include('Nothing here').and.to.include('Add');

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-item-row.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-item-row.tsx
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { nls } from '@theia/core';
 import { codicon } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { AiConfigurationItemStatus } from '../ai-configuration-category';
@@ -68,6 +69,59 @@ export interface AiConfigurationItemRowProps {
 }
 
 /**
+ * A row's description, clamped to two lines so a long list stays scannable, with a toggle that reveals the
+ * rest in place. Without it the remainder of a long description (a tool's, in particular, often runs to
+ * several sentences) was simply unreachable; showing every description in full instead made the Tools page
+ * far too long to scroll.
+ *
+ * The toggle appears only once the text is measured as actually clamped, since that depends on the rendered
+ * width; measuring is skipped while expanded, where the clamp is lifted and nothing overflows.
+ */
+const AiConfigurationItemRowDescription: React.FC<{ description: string }> = ({ description }) => {
+    const [expanded, setExpanded] = React.useState(false);
+    const [clamped, setClamped] = React.useState(false);
+    // eslint-disable-next-line no-null/no-null
+    const descriptionRef = React.useRef<HTMLSpanElement>(null);
+
+    React.useLayoutEffect(() => {
+        const element = descriptionRef.current;
+        if (!element || expanded) {
+            return;
+        }
+        // Sub-pixel line heights make an unclamped element report a slightly larger scroll height.
+        const measure = () => setClamped(element.scrollHeight - element.clientHeight > 1);
+        measure();
+        // Narrowing the view can clamp a description that fit before, so re-measure on width changes.
+        // Guarded because JSDOM, which the component specs render into, has no `ResizeObserver`.
+        if (typeof ResizeObserver === 'undefined') {
+            return;
+        }
+        const observer = new ResizeObserver(measure);
+        observer.observe(element);
+        return () => observer.disconnect();
+    }, [description, expanded]);
+
+    const onToggle = (event: React.MouseEvent): void => {
+        // A navigable row would otherwise also handle the click and open its own detail.
+        event.stopPropagation();
+        setExpanded(previous => !previous);
+    };
+
+    return <>
+        <span
+            ref={descriptionRef}
+            className={`ai-configuration-item-row-description${expanded ? ' expanded' : ''}`}
+        >{description}</span>
+        {clamped && <button
+            type='button'
+            className='ai-configuration-item-row-description-toggle'
+            aria-expanded={expanded}
+            onClick={onToggle}
+        >{expanded ? nls.localizeByDefault('Show Less') : nls.localizeByDefault('Show More')}</button>}
+    </>;
+};
+
+/**
  * Overview row for a collection item: an icon, a label with an optional description, and a right-hand slot
  * for a status badge / stats / an inline control. When {@link AiConfigurationItemRowProps.onSelect} is given
  * the whole row is a single navigable control (click or Enter/Space) that opens the item's detail page,
@@ -116,7 +170,7 @@ export const AiConfigurationItemRow: React.FC<AiConfigurationItemRowProps> = ({
                 </span>}
                 <AiConfigurationOriginBadges origins={origins} />
             </div>
-            {description && <span className='ai-configuration-item-row-description'>{description}</span>}
+            {description && <AiConfigurationItemRowDescription description={description} />}
         </div>
         <div className='ai-configuration-item-row-trailing'>
             {status && <AiConfigurationStatusBadge status={status} />}

--- a/packages/ai-core-ui/src/browser/style/ai-configuration-components.css
+++ b/packages/ai-core-ui/src/browser/style/ai-configuration-components.css
@@ -777,6 +777,36 @@
   -webkit-box-orient: vertical;
 }
 
+/* Expanding lifts the clamp and nothing else: the box formatting, font and (inherited) line height stay
+   exactly as they are while collapsed, so the two lines already on screen do not shift when the rest of the
+   text appears below them. */
+.ai-configuration-item-row-description.expanded {
+  -webkit-line-clamp: unset;
+}
+
+/* Rendered only for a description that is actually clamped, so it reads as a link continuing the truncated
+   text rather than as another of the row's controls. A button does not inherit the surrounding font, so it
+   would otherwise render in the browser's default one. */
+.ai-configuration-item-row-description-toggle {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--theia-textLink-foreground);
+  font: inherit;
+  font-size: var(--theia-ui-font-size1);
+  cursor: pointer;
+}
+
+.ai-configuration-item-row-description-toggle:hover {
+  text-decoration: underline;
+}
+
+.ai-configuration-item-row-description-toggle:focus-visible {
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: 1px;
+}
+
 .ai-configuration-item-row-trailing {
   display: flex;
   align-items: center;

--- a/packages/ai-ide/src/browser/ai-configuration/language-model-renderer.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/language-model-renderer.tsx
@@ -60,7 +60,7 @@ const ModelSelect: React.FC<{
     }, [onSelect, purpose]);
     return <SelectComponent
         id={id}
-        className='ai-config-select ai-configuration-value-row-value'
+        className='ai-config-select'
         options={options}
         defaultValue={value}
         onChange={handleChange}
@@ -120,7 +120,7 @@ export const ReasoningRow: React.FC<{
                 reasoningLevelLabel(inheritedLevel))}
         modified={savedLevel !== undefined}
         below={<SelectComponent
-            className={`ai-config-select ai-configuration-value-row-value theia-ReasoningLevelSelector reasoning-level-${effectiveLevel}`}
+            className={`ai-config-select theia-ReasoningLevelSelector reasoning-level-${effectiveLevel}`}
             options={options}
             defaultValue={effectiveLevel}
             onChange={handleChange}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

 - The model and reasoning selects in the agent detail no longer render in the monospace editor font. They reused
  `ai-configuration-value-row-value`, which styles read-only code values and also added a second border and background around the
  select.
  - A tool description in the Tools view can now be read in full. Descriptions are still clamped to two lines, but get a "Show More" /
  "Show Less" toggle when the text is actually cut off. Expanding lifts only the clamp, so the visible lines don't shift.

  The second fix is in the shared `AiConfigurationItemRow`, so it also applies to the MCP servers and agent capability lists.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the AI Configuration view.
2. Agents → pick an agent: the "Purpose" and "Reasoning" selects use the regular UI font, with a single border.
3. Tools: rows with a long description show "Show More"; clicking it reveals the rest without the text above it moving, and "Show Less" collapses it again. Short descriptions show no toggle. Narrow the view and check the toggle appears for descriptions that no longer fit.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
