### PR TITLE
fix(plugin-ext): route setTextDocumentLanguage to the notebook cell model

### DIFF
--- a/packages/plugin-ext/src/main/browser/languages-main.spec.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.spec.ts
@@ -1,0 +1,101 @@
+// *****************************************************************************
+// Copyright (C) 2026 JuliaHub, Inc. and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// `languages-main` transitively pulls in Monaco and several frontend modules that touch `document`
+// at module-load time.
+const disableJSDOM = enableJSDOM();
+import { expect } from 'chai';
+import * as monaco from '@theia/monaco-editor-core';
+import { mainWindow } from '@theia/monaco-editor-core/esm/vs/base/browser/window';
+import { URI } from '@theia/core/lib/common/uri';
+import { expectThrowsAsync } from '@theia/core/lib/common/test/expect';
+import { CellEditType, CellUri } from '@theia/notebook/lib/common';
+import { CellEditOperation } from '@theia/notebook/lib/browser/notebook-types';
+import type { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
+import { LanguagesMainImpl } from './languages-main';
+
+after(() => disableJSDOM());
+
+const notebookUri = new URI('file:///notebook.ipynb');
+const cellHandle = 3;
+const cellComponents = CellUri.generate(notebookUri, cellHandle).toComponents();
+
+type FakeNotebookModel = Pick<NotebookModel, 'getCellIndexByHandle' | 'applyEdits'> & {
+    edits: CellEditOperation[][];
+};
+
+function createNotebookModel(handles: number[]): FakeNotebookModel {
+    const edits: CellEditOperation[][] = [];
+    return {
+        edits,
+        getCellIndexByHandle: handle => handles.indexOf(handle),
+        applyEdits: applied => { edits.push(applied); }
+    };
+}
+
+/**
+ * Bypasses the constructor's RPC/container wiring.
+ */
+function createLanguagesMain(notebook?: FakeNotebookModel): LanguagesMainImpl {
+    const languagesMain = Object.create(LanguagesMainImpl.prototype) as LanguagesMainImpl;
+    (languagesMain as unknown as Record<string, unknown>).notebookService = {
+        getNotebookEditorModel: (uri: URI) => uri.toString() === notebookUri.toString() ? notebook : undefined
+    };
+    return languagesMain;
+}
+
+describe('LanguagesMainImpl#$changeLanguage', () => {
+
+    before(() => {
+        // Resolving a language id boots Monaco's standalone services, whose theme service reaches for
+        // DOM APIs JSDOM does not provide. Monaco captures its window at module load.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (global as any).CSS ??= { escape: (value: string) => value };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mainWindow as any).matchMedia ??= () => ({ matches: false, addEventListener: () => { }, removeEventListener: () => { } });
+        monaco.languages.register({ id: 'julia' });
+    });
+
+    it('applies a cell language edit for a notebook cell', async () => {
+        const notebook = createNotebookModel([1, 2, cellHandle]);
+        const languagesMain = createLanguagesMain(notebook);
+
+        await languagesMain.$changeLanguage(cellComponents, 'julia');
+
+        expect(notebook.edits).to.deep.equal([[{ editType: CellEditType.CellLanguage, index: 2, language: 'julia' }]]);
+    });
+
+    it('rejects for a cell of a notebook that is not open', async () => {
+        const languagesMain = createLanguagesMain();
+
+        await expectThrowsAsync(languagesMain.$changeLanguage(cellComponents, 'julia'), 'Invalid uri');
+    });
+
+    it('rejects for a cell handle the notebook does not know', async () => {
+        const languagesMain = createLanguagesMain(createNotebookModel([1, 2]));
+
+        await expectThrowsAsync(languagesMain.$changeLanguage(cellComponents, 'julia'), 'Invalid uri');
+    });
+
+    it('rejects an unknown language id before touching the notebook', async () => {
+        const notebook = createNotebookModel([cellHandle]);
+        const languagesMain = createLanguagesMain(notebook);
+
+        await expectThrowsAsync(languagesMain.$changeLanguage(cellComponents, 'no-such-language'), /Unknown language ID/);
+        expect(notebook.edits).to.be.empty;
+    });
+});

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -88,6 +88,8 @@ import { CodeActionTriggerKind } from '../../plugin/types-impl';
 import { IReadonlyVSDataTransfer } from '@theia/monaco-editor-core/esm/vs/base/common/dataTransfer';
 import { FileUploadService } from '@theia/filesystem/lib/common/upload/file-upload';
 import { ILogger } from '@theia/core';
+import { NotebookService } from '@theia/notebook/lib/browser';
+import { CellEditType, CellUri } from '@theia/notebook/lib/common';
 
 @injectable()
 export class LanguagesMainImpl implements LanguagesMain, Disposable {
@@ -110,6 +112,9 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
     @inject(FileUploadService)
     protected readonly fileUploadService: FileUploadService;
 
+    @inject(NotebookService)
+    protected readonly notebookService: NotebookService;
+
     @inject(ILogger) @named('plugin-ext:LanguagesMainImpl')
     protected readonly logger: ILogger;
 
@@ -129,18 +134,35 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return Promise.resolve(monaco.languages.getLanguages().map(l => l.id));
     }
 
-    $changeLanguage(resource: UriComponents, languageId: string): Promise<void> {
-        const uri = monaco.Uri.revive(resource);
-        const model = monaco.editor.getModel(uri);
-        if (!model) {
-            return Promise.reject(new Error('Invalid uri'));
+    async $changeLanguage(resource: UriComponents, languageId: string): Promise<void> {
+        if (!monaco.languages.getEncodedLanguageId(languageId)) {
+            throw new Error(`Unknown language ID: ${languageId}`);
         }
-        const langId = monaco.languages.getEncodedLanguageId(languageId);
-        if (!langId) {
-            return Promise.reject(new Error(`Unknown language ID: ${languageId}`));
+        const cell = CellUri.parse(URI.fromComponents(resource));
+        if (cell) {
+            this.changeCellLanguage(cell.notebook, cell.handle, languageId);
+            return;
+        }
+        const model = monaco.editor.getModel(monaco.Uri.revive(resource));
+        if (!model) {
+            throw new Error('Invalid uri');
         }
         monaco.editor.setModelLanguage(model, languageId);
-        return Promise.resolve(undefined);
+    }
+
+    /**
+     * The cell model owns a cell's language; kernel selection, serialization, and the cell editor all follow it.
+     */
+    protected changeCellLanguage(notebookUri: URI, handle: number, languageId: string): void {
+        const notebook = this.notebookService.getNotebookEditorModel(notebookUri);
+        if (!notebook) {
+            throw new Error('Invalid uri');
+        }
+        const index = notebook.getCellIndexByHandle(handle);
+        if (index < 0) {
+            throw new Error('Invalid uri');
+        }
+        notebook.applyEdits([{ editType: CellEditType.CellLanguage, index, language: languageId }], true);
     }
 
     protected register(handle: number, service: Disposable): void {


### PR DESCRIPTION
#### What it does

`languages.setTextDocumentLanguage` was a silent no-op for notebook cells. It resolved the cell's Monaco text model and set the language on that, which never reaches the cell model: the cell model listens for content changes on its text model, not for a language change. The call resolved successfully and nothing changed — no rejection, no error, which is what makes it hard to diagnose from a plugin.

In Theia the cell model is the authority and the text model is downstream of it — the opposite of VS Code, so VS Code's mirror-back listener in `notebookCellTextModel` cannot be ported. The cell model holds the language the execution service filters kernels on, and a cell whose language is not in the selected kernel's `supportedLanguages` has its execution completed with an empty result: no error, no output, Run appears to do nothing. It is also the value the serializer writes back and the value that drives the editor's highlighting.

A cell URI is now routed through the notebook model's `CellLanguage` edit — the same path the `notebook.cell.changeLanguage` command takes — which additionally propagates the language back to the plugin host so `cell.document.languageId` agrees.

Validating the language id moved ahead of both paths, so a bogus id is reported as such rather than being masked by a missing text model. That flips precedence for one case: a call with both a bad URI and a bad language id now reports the language id.

#### How to test

Open an `.ipynb` with no top-level `metadata` in the browser example (`vscode.ipynb` then deserializes every code cell as `python`) and, from a plugin, call `vscode.languages.setTextDocumentLanguage(cell.document, 'plaintext')` on every code cell. On master all calls resolve and every cell stays `python`. With this change the cells report `plaintext` on `cell.document.languageId`, the language indicator and highlighting follow, and `vscode.ipynb` writes the new language back into each cell on save.

The case this came from: julia-vscode calls `setTextDocumentLanguage` on every code cell from `onDidChangeSelectedNotebooks` to repair exactly this situation, which is why the bug is invisible in VS Code. With `julialang.language-julia` and `vscode.ipynb` installed, opening such a notebook and selecting a Julia kernel silently dropped every Run, since the Julia controller declares `supportedLanguages = ['julia', 'raw']` and the cells stayed `python`.

#### What was deliberately left behind

The non-cell path is untouched. Routing it through `MonacoTextModelService.createModelReference` was tried and dropped: a document the plugin host knows about always already has a Monaco model, because the host learns of documents through `onModelAdded`, which is `MonacoTextModelService.onDidCreate`. So `getModel` returns `undefined` only for URIs no plugin has open, and for those, acquiring a reference and releasing it destroys the model again on the last release, discarding the language change and emitting a spurious open/close document pair.

A cell whose Monaco model is resolved while its editor is unmounted also keeps a stale Monaco language, because the model update rides the editor's `onDidChangeLanguage` subscription. Pre-existing, and shared with the `notebook.cell.changeLanguage` command.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service
