### PR TITLE
feat(ai-copilot): support images with copilot models

### DIFF
--- a/packages/ai-copilot/README.md
+++ b/packages/ai-copilot/README.md
@@ -125,7 +125,8 @@ It is used for the sign-in, and remembered with the credentials so that requests
   - The conversation is flattened into one prompt. A single user turn is forwarded as it is, a longer history is rendered as a
     role-labelled transcript. The system prompt of the Theia agent is not part of that, it becomes the system message of the
     session and takes the place of the agent instructions the CLI would use.
-  - Images in a request are dropped and only noted as omitted.
+  - Images in a request are sent as inline attachments when they are base64-encoded; images given as a URL are dropped
+    and only noted as omitted, because the SDK's attachments carry inline data rather than a remote reference.
   - Tool calls and tool results of the history are rendered as text rather than as the structured entries they were.
 
 ## Additional Information

--- a/packages/ai-copilot/src/node/copilot-sdk-language-model.spec.ts
+++ b/packages/ai-copilot/src/node/copilot-sdk-language-model.spec.ts
@@ -49,9 +49,10 @@ class TestableCopilotSdkLanguageModel extends CopilotSdkLanguageModel {
      * Runs a request against a session that reports itself idle as soon as it was sent to, and
      * reports what the session was configured with, what it was sent, and what was discarded.
      */
-    async captureTurn(request: UserRequest): Promise<{ config: Record<string, unknown>, prompt?: string, deleted?: string }> {
+    async captureTurn(request: UserRequest): Promise<{ config: Record<string, unknown>, prompt?: string, attachments?: unknown[], deleted?: string }> {
         let config: Record<string, unknown> = {};
         let prompt: string | undefined;
+        let attachments: unknown[] | undefined;
         let deleted: string | undefined;
         const listeners = new Map<string, (event: unknown) => void>();
         const session = {
@@ -60,8 +61,9 @@ class TestableCopilotSdkLanguageModel extends CopilotSdkLanguageModel {
                 listeners.set(event, handler);
                 return () => listeners.delete(event);
             },
-            send: async (message: { prompt: string }) => {
+            send: async (message: { prompt: string, attachments?: unknown[] }) => {
                 prompt = message.prompt;
+                attachments = message.attachments;
                 listeners.get('session.idle')?.({});
             },
             abort: async () => { },
@@ -81,7 +83,7 @@ class TestableCopilotSdkLanguageModel extends CopilotSdkLanguageModel {
         for await (const part of response.stream) {
             expect(part).to.exist;
         }
-        return { config, prompt, deleted };
+        return { config, prompt, attachments, deleted };
     }
 }
 
@@ -256,6 +258,18 @@ describe('CopilotSdkLanguageModel - turn', () => {
     it('should delete the session it created, which the CLI would otherwise keep', async () => {
         const { deleted } = await model.captureTurn(request);
         expect(deleted).to.equal('test-session');
+    });
+
+    it('should send a base64 image of the request as a blob attachment', async () => {
+        const requestWithImage = {
+            messages: [
+                { actor: 'user', type: 'text', text: 'what is this?' },
+                { actor: 'user', type: 'image', image: { base64data: 'aGk=', mimeType: 'image/png' } }
+            ]
+        } as unknown as UserRequest;
+        const { prompt, attachments } = await model.captureTurn(requestWithImage);
+        expect(prompt).to.equal('what is this?');
+        expect(attachments).to.deep.equal([{ type: 'blob', data: 'aGk=', mimeType: 'image/png' }]);
     });
 });
 

--- a/packages/ai-copilot/src/node/copilot-sdk-language-model.ts
+++ b/packages/ai-copilot/src/node/copilot-sdk-language-model.ts
@@ -24,7 +24,7 @@ import {
     UserRequest
 } from '@theia/ai-core';
 import { CancellationToken, ILogger } from '@theia/core';
-import type { CopilotClient, CopilotSession, PermissionHandler, Tool } from './copilot-sdk-types';
+import type { BlobMessageAttachment, CopilotClient, CopilotSession, PermissionHandler, Tool } from './copilot-sdk-types';
 import { buildSdkPrompt, buildSdkSystemMessage } from './copilot-sdk-mappers';
 
 /**
@@ -155,7 +155,7 @@ export class CopilotSdkLanguageModel implements LanguageModel {
 
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {
         const client = await this.clientProvider();
-        const { systemText, prompt } = buildSdkPrompt(request.messages);
+        const { systemText, prompt, attachments } = buildSdkPrompt(request.messages);
         const sink = new CopilotStreamSink();
 
         const tools = this.createTools(request.tools ?? [], sink);
@@ -177,7 +177,7 @@ export class CopilotSdkLanguageModel implements LanguageModel {
             onPermissionRequest: approveTheiaTools
         });
 
-        return { stream: this.streamResponse(client, session, prompt, sink, cancellationToken) };
+        return { stream: this.streamResponse(client, session, prompt, attachments, sink, cancellationToken) };
     }
 
     /**
@@ -235,6 +235,7 @@ export class CopilotSdkLanguageModel implements LanguageModel {
         client: CopilotClient,
         session: CopilotSession,
         prompt: string,
+        attachments: BlobMessageAttachment[] | undefined,
         sink: CopilotStreamSink,
         cancellationToken?: CancellationToken
     ): AsyncIterable<LanguageModelStreamResponsePart> {
@@ -292,7 +293,7 @@ export class CopilotSdkLanguageModel implements LanguageModel {
             } else {
                 // Deliberately not awaited: the turn only completes after the tool loop has run, and
                 // its parts have to be yielded while that happens.
-                session.send({ prompt }).catch(error => sink.finish(error));
+                session.send({ prompt, attachments }).catch(error => sink.finish(error));
             }
             yield* sink.drain();
             if (inputTokens !== undefined || outputTokens !== undefined) {

--- a/packages/ai-copilot/src/node/copilot-sdk-mappers.spec.ts
+++ b/packages/ai-copilot/src/node/copilot-sdk-mappers.spec.ts
@@ -120,6 +120,43 @@ describe('copilot-sdk-mappers - buildSdkPrompt', () => {
             'User: run it\n\nAssistant: [tool call: foo {"x":1}]\n\nUser: [tool result: done]'
         );
     });
+
+    it('turns a base64 user image into a blob attachment and drops it from the prompt text', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'what is this?' },
+            { actor: 'user', type: 'image', image: { base64data: 'aGk=', mimeType: 'image/png' } }
+        ];
+        const result = buildSdkPrompt(messages);
+        expect(result.prompt).to.equal('what is this?');
+        expect(result.attachments).to.deep.equal([{ type: 'blob', data: 'aGk=', mimeType: 'image/png' }]);
+    });
+
+    it('collects multiple base64 images in message order', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'image', image: { base64data: 'AAA=', mimeType: 'image/png' } },
+            { actor: 'user', type: 'image', image: { base64data: 'BBB=', mimeType: 'image/jpeg' } }
+        ];
+        const result = buildSdkPrompt(messages);
+        expect(result.attachments).to.deep.equal([
+            { type: 'blob', data: 'AAA=', mimeType: 'image/png' },
+            { type: 'blob', data: 'BBB=', mimeType: 'image/jpeg' }
+        ]);
+    });
+
+    it('leaves attachments undefined when there are no images', () => {
+        const result = buildSdkPrompt([{ actor: 'user', type: 'text', text: 'hi' }]);
+        expect(result.attachments).to.be.undefined;
+    });
+
+    it('does not attach a URL image and renders it as an omitted placeholder instead', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'look' },
+            { actor: 'user', type: 'image', image: { url: 'https://example.com/a.png' } }
+        ];
+        const result = buildSdkPrompt(messages);
+        expect(result.attachments).to.be.undefined;
+        expect(result.prompt).to.equal('User: look\n\nUser: [image omitted]');
+    });
 });
 
 describe('copilot-sdk-mappers - buildSdkSystemMessage', () => {

--- a/packages/ai-copilot/src/node/copilot-sdk-mappers.ts
+++ b/packages/ai-copilot/src/node/copilot-sdk-mappers.ts
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelMessage } from '@theia/ai-core';
-import type { ModelInfo, SystemMessageConfig } from './copilot-sdk-types';
+import { Base64ImageContent, ImageContent, ImageMessage, LanguageModelMessage } from '@theia/ai-core';
+import type { BlobMessageAttachment, ModelInfo, SystemMessageConfig } from './copilot-sdk-types';
 
 /**
  * Recognizes an id that names a dated release of another model, such as
@@ -64,6 +64,8 @@ export interface SdkPrompt {
     systemText: string;
     /** The user-facing prompt body derived from the non-system messages. */
     prompt: string;
+    /** Base64-encoded images pulled out of the user's messages, sent alongside the prompt. */
+    attachments?: BlobMessageAttachment[];
 }
 
 function roleLabel(message: LanguageModelMessage): string {
@@ -75,6 +77,17 @@ function roleLabel(message: LanguageModelMessage): string {
         default:
             return 'User';
     }
+}
+
+/**
+ * Whether a message is a user image the SDK can be sent as a blob attachment.
+ *
+ * URL images are not covered: the SDK's attachments carry inline data, not a remote reference,
+ * and fetching the URL on the backend to inline it would add a server-side-request-forgery
+ * surface for what is, today, not a use case Theia exercises.
+ */
+function isAttachableImageMessage(message: LanguageModelMessage): message is ImageMessage & { image: Base64ImageContent } {
+    return LanguageModelMessage.isImageMessage(message) && message.actor === 'user' && ImageContent.isBase64(message.image);
 }
 
 function messageToText(message: LanguageModelMessage): string {
@@ -91,6 +104,7 @@ function messageToText(message: LanguageModelMessage): string {
         return `[tool result: ${content}]`;
     }
     if (LanguageModelMessage.isImageMessage(message)) {
+        // Reached for URL images and non-user image messages; base64 user images are attachments instead, see buildSdkPrompt.
         return '[image omitted]';
     }
     return '';
@@ -105,16 +119,23 @@ function messageToText(message: LanguageModelMessage): string {
  * see {@link buildSdkSystemMessage}. A lone user turn is forwarded verbatim;
  * richer histories are rendered as a role-labelled transcript.
  *
- * This is a lossy mapping by design, see the limitations documented in the package
- * README, and is intended for single-turn requests.
+ * Base64 user images are pulled out of the history and sent as blob attachments instead of
+ * being flattened into the prompt text, see {@link isAttachableImageMessage}. This is otherwise
+ * a lossy mapping by design, see the limitations documented in the package README, and is
+ * intended for single-turn requests.
  */
 export function buildSdkPrompt(messages: LanguageModelMessage[]): SdkPrompt {
     const systemParts: string[] = [];
     const conversation: LanguageModelMessage[] = [];
+    const attachments: BlobMessageAttachment[] = [];
     for (const message of messages) {
         if (message.actor === 'system' && LanguageModelMessage.isTextMessage(message)) {
             systemParts.push(message.text);
-        } else if (message.type !== 'thinking') {
+        } else if (message.type === 'thinking') {
+            continue;
+        } else if (isAttachableImageMessage(message)) {
+            attachments.push({ type: 'blob', data: message.image.base64data, mimeType: message.image.mimeType });
+        } else {
             conversation.push(message);
         }
     }
@@ -131,7 +152,7 @@ export function buildSdkPrompt(messages: LanguageModelMessage[]): SdkPrompt {
             .trim();
     }
 
-    return { systemText, prompt };
+    return { systemText, prompt, attachments: attachments.length > 0 ? attachments : undefined };
 }
 
 /**

--- a/packages/ai-copilot/src/node/copilot-sdk-types.ts
+++ b/packages/ai-copilot/src/node/copilot-sdk-types.ts
@@ -191,8 +191,22 @@ export interface CopilotSessionEvents {
 export type CopilotSessionEventType = keyof CopilotSessionEvents;
 
 // ============================================================================
-// Session, from `dist/session.d.ts`
+// Session, from `dist/session.d.ts` and `dist/types.d.ts`
 // ============================================================================
+
+/** The one attachment kind this integration produces: an inline image, from `MessageOptions['attachments']`. */
+export interface BlobMessageAttachment {
+    type: 'blob';
+    data: string;
+    mimeType: string;
+    displayName?: string;
+}
+
+/** The options this integration passes to {@link CopilotSession.send}. */
+export interface MessageOptions {
+    prompt: string;
+    attachments?: BlobMessageAttachment[];
+}
 
 /** A conversation with the runtime, upstream a class with resume, fork and sharing on top. */
 export interface CopilotSession {
@@ -202,7 +216,7 @@ export interface CopilotSession {
      */
     on<K extends CopilotSessionEventType>(eventType: K, handler: (event: CopilotSessionEvents[K]) => void): () => void;
     /** Sends a turn and resolves with the id of the message it created. */
-    send(options: { prompt: string }): Promise<string>;
+    send(options: MessageOptions): Promise<string>;
     /** Stops the turn in flight. */
     abort(): Promise<void>;
     /** Releases the session in memory, leaving what it persisted in place. */

--- a/scripts/copilot-sdk-mirror/check.ts
+++ b/scripts/copilot-sdk-mirror/check.ts
@@ -38,6 +38,7 @@ declare function value<T>(): T;
 export const options: Sdk.CopilotClientOptions = value<Mirror.CopilotClientOptions>();
 export const sessionConfig: Sdk.SessionConfig = value<Mirror.SessionConfig>();
 export const tool: Sdk.Tool = value<Mirror.Tool>();
+export const messageOptions: Sdk.MessageOptions = value<Mirror.MessageOptions>();
 export const systemMessage: Sdk.SystemMessageConfig = value<Mirror.SystemMessageConfig>();
 export const permissionHandler: Sdk.PermissionHandler = value<Mirror.PermissionHandler>();
 export const connection: Sdk.RuntimeConnection = value<Mirror.StdioRuntimeConnection>();


### PR DESCRIPTION
#### What it does

Recently experimental support for copilot models via copilot sdk was added. The feature is missing support to send images.

This change will attach the images to the message send to the copilot sdk.

#### How to test

* Select a (multi-model)  copilot model
* Attach an image to the conversation
* The LLM should be able to explain the content of the image

#### Follow-ups

* As currently the whole chat history is sent as one message and the images are attached to this message, there might be an impact on caching.

#### Breaking changes

#### Attribution

Contributed on behalf of MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
