### PR TITLE
feat(ai): deliver volatile editor context per turn instead of in system prompts

### DIFF
--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -134,14 +134,15 @@ export default new ContainerModule(bind => {
     bind(PendingToolConfirmationTracker).toSelf().inSingletonScope();
 
     bind(CustomChatAgent).toSelf();
-    bind(CustomAgentFactory).toFactory<CustomChatAgent, [string, string, string, string, string, boolean | undefined, CustomAgentPromptVariant[] | undefined]>(
-        ctx => (id, name, description, prompt, defaultLLM, showInChat, promptVariants) => {
+    bind(CustomAgentFactory).toFactory<CustomChatAgent, [string, string, string, string, string, boolean | undefined, CustomAgentPromptVariant[] | undefined, string | undefined]>(
+        ctx => (id, name, description, prompt, defaultLLM, showInChat, promptVariants, turnPrompt) => {
             const agent = ctx.container.get<CustomChatAgent>(CustomChatAgent);
             agent.id = id;
             agent.name = name;
             agent.description = description;
             agent.prompt = prompt;
             agent.promptVariants = promptVariants;
+            agent.turnPrompt = turnPrompt;
             agent.languageModelRequirements = [{
                 purpose: 'chat',
                 identifier: defaultLLM,

--- a/packages/ai-chat/src/browser/change-set-variable.ts
+++ b/packages/ai-chat/src/browser/change-set-variable.ts
@@ -25,6 +25,7 @@ export const CHANGE_SET_SUMMARY_VARIABLE: AIVariable = {
     description: nls.localize('theia/ai/core/changeSetSummaryVariable/description', 'Provides a summary of the files in a change set and their contents.'),
 
     name: CHANGE_SET_SUMMARY_VARIABLE_ID,
+    isVolatile: true
 };
 
 @injectable()

--- a/packages/ai-chat/src/browser/custom-agent-factory.ts
+++ b/packages/ai-chat/src/browser/custom-agent-factory.ts
@@ -25,5 +25,6 @@ export type CustomAgentFactory = (
     prompt: string,
     defaultLLM: string,
     showInChat?: boolean,
-    promptVariants?: CustomAgentPromptVariant[]
+    promptVariants?: CustomAgentPromptVariant[],
+    turnPrompt?: string
 ) => CustomChatAgent;

--- a/packages/ai-chat/src/browser/custom-agent-frontend-application-contribution.ts
+++ b/packages/ai-chat/src/browser/custom-agent-frontend-application-contribution.ts
@@ -105,7 +105,7 @@ export class AICustomAgentsFrontendApplicationContribution implements FrontendAp
             this.knownCustomAgents.delete(id);
         });
         customAgentsToAdd.forEach(agent => {
-            this.customAgentFactory(agent.id, agent.name, agent.description, agent.prompt, agent.defaultLLM, agent.showInChat, agent.promptVariants);
+            this.customAgentFactory(agent.id, agent.name, agent.description, agent.prompt, agent.defaultLLM, agent.showInChat, agent.promptVariants, agent.turnPrompt);
             this.knownCustomAgents.set(agent.id, agent);
         });
     }

--- a/packages/ai-chat/src/common/chat-agents.spec.ts
+++ b/packages/ai-chat/src/common/chat-agents.spec.ts
@@ -18,10 +18,12 @@ import 'reflect-metadata';
 
 import { expect } from 'chai';
 import {
+    CapabilityAwareContext, GENERIC_CAPABILITIES_FUNCTIONS_PROMPT_ID,
     LanguageModel, LanguageModelMessage, LanguageModelRegistry, LanguageModelRequirement, LanguageModelResponse,
-    LanguageModelSelector, LanguageModelService, LanguageModelStreamResponsePart, ServerToolDescriptor, UserRequest
+    LanguageModelSelector, LanguageModelService, LanguageModelStreamResponsePart, PromptService, ResolvedAIVariable, ResolvedPromptFragment, ServerToolDescriptor, UserRequest
 } from '@theia/ai-core';
-import { AbstractChatAgent, AbstractStreamParsingChatAgent, ChatAgentLocation } from './chat-agents';
+import { AbstractChatAgent, AbstractStreamParsingChatAgent, ChatAgentLocation, ChatSessionContext, SystemMessageDescription } from './chat-agents';
+import { CustomChatAgent } from './custom-chat-agent';
 import {
     ChatResponseContent,
     CompactionChatResponseContent,
@@ -34,8 +36,16 @@ import {
 } from './chat-model';
 import { ParsedChatRequest, ParsedChatRequestTextPart } from './parsed-chat-request';
 import { FileReadTracker } from './file-read-tracker';
-import { ILogger } from '@theia/core';
+import { ILogger, Loggable } from '@theia/core';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+
+class RecordingLogger extends MockLogger {
+    readonly warnings: string[] = [];
+    override warn(arg: string | Loggable, ...params: unknown[]): Promise<void> {
+        this.warnings.push(String(arg));
+        return Promise.resolve();
+    }
+}
 
 class TestChatAgent extends AbstractChatAgent {
     readonly id = 'test-agent';
@@ -70,6 +80,36 @@ class TestChatAgent extends AbstractChatAgent {
 
     public setFileReadTracker(tracker: FileReadTracker): void {
         this.fileReadTracker = tracker;
+    }
+
+    public setTurnPromptId(id: string | undefined): void {
+        this.turnPromptId = id;
+    }
+
+    public setSystemPromptId(id: string | undefined): void {
+        this.systemPromptId = id;
+    }
+
+    public setPromptService(service: PromptService): void {
+        this.promptService = service;
+    }
+
+    public exposeResolveTurnPrompt(context: ChatSessionContext): Promise<ResolvedPromptFragment | undefined> {
+        return this.resolveTurnPrompt(context);
+    }
+
+    public useRecordingLogger(): RecordingLogger {
+        const logger = new RecordingLogger();
+        this.logger = logger;
+        return logger;
+    }
+
+    public exposeWarnAboutVolatileSystemPromptVariables(description: SystemMessageDescription): void {
+        this.warnAboutVolatileSystemPromptVariables(description);
+    }
+
+    public exposeAppendGenericCapabilities(systemMessage: SystemMessageDescription, context: CapabilityAwareContext): Promise<SystemMessageDescription> {
+        return this.appendGenericCapabilities(systemMessage, context);
     }
 
 }
@@ -151,6 +191,107 @@ describe('AbstractChatAgent.getMessages', () => {
             .filter(m => m.actor === 'ai');
         expect(aiTextMessages).to.have.lengthOf(1);
         expect(aiTextMessages[0].text).to.equal('Partial reply before cancel');
+    });
+});
+
+describe('AbstractChatAgent turn prompt', () => {
+
+    function summarize(messages: LanguageModelMessage[]): string[] {
+        return messages.map(message => message.type === 'text' ? `${message.actor}:${message.text}` : message.type);
+    }
+
+    it('appends a stored turn prompt to the user text of its request, in the same user message, for every request', async () => {
+        const agent = new TestChatAgent();
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        const first = model.addRequest(createParsedRequest('First'));
+        first.setTurnPrompt('editors: a.ts');
+        first.response.response.addContent(new TextChatResponseContentImpl('Reply 1'));
+        first.response.complete();
+        const second = model.addRequest(createParsedRequest('Second'));
+        second.response.response.addContent(new TextChatResponseContentImpl('Reply 2'));
+        second.response.complete();
+        const third = model.addRequest(createParsedRequest('Third'));
+        third.setTurnPrompt('editors: b.ts');
+
+        const messages = await agent.exposeGetMessages(model);
+
+        expect(summarize(messages)).to.deep.equal([
+            'user:First\n\neditors: a.ts', 'ai:Reply 1',
+            'user:Second', 'ai:Reply 2',
+            'user:Third\n\neditors: b.ts'
+        ]);
+    });
+
+    it('sends the turn prompt alone when the request has no text', async () => {
+        const agent = new TestChatAgent();
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        model.addRequest(createParsedRequest('')).setTurnPrompt('editors: c.ts');
+
+        const messages = await agent.exposeGetMessages(model);
+
+        expect(summarize(messages)).to.deep.equal(['user:editors: c.ts']);
+    });
+
+    it('resolves the declared turn prompt fragment with the session context', async () => {
+        const agent = new TestChatAgent();
+        agent.setTurnPromptId('my-turn-prompt');
+        const calls: unknown[][] = [];
+        agent.setPromptService({
+            getResolvedPromptFragment: async (id: string, args: unknown, ctx: unknown) => {
+                calls.push([id, args, ctx]);
+                return { id, text: 'current state' };
+            }
+        } as unknown as PromptService);
+        const context: ChatSessionContext = { model: new MutableChatModel(ChatAgentLocation.Panel) };
+
+        const resolved = await agent.exposeResolveTurnPrompt(context);
+
+        expect(resolved?.text).to.equal('current state');
+        expect(calls).to.deep.equal([['my-turn-prompt', undefined, context]]);
+    });
+
+    it('resolves nothing when no turn prompt is declared', async () => {
+        const agent = new TestChatAgent();
+        agent.setPromptService({
+            getResolvedPromptFragment: async () => { throw new Error('must not be called'); }
+        } as unknown as PromptService);
+
+        const resolved = await agent.exposeResolveTurnPrompt({ model: new MutableChatModel(ChatAgentLocation.Panel) });
+
+        expect(resolved).to.equal(undefined);
+    });
+
+    it('warns once when the declared turn prompt id names no existing fragment, naming the agent and the fragment id', async () => {
+        const agent = new TestChatAgent();
+        const logger = agent.useRecordingLogger();
+        agent.setTurnPromptId('no-such-fragment');
+        agent.setPromptService({
+            getResolvedPromptFragment: async () => undefined
+        } as unknown as PromptService);
+        const context: ChatSessionContext = { model: new MutableChatModel(ChatAgentLocation.Panel) };
+
+        const first = await agent.exposeResolveTurnPrompt(context);
+        const second = await agent.exposeResolveTurnPrompt(context);
+
+        expect(first).to.equal(undefined);
+        expect(second).to.equal(undefined);
+        expect(logger.warnings).to.have.lengthOf(1);
+        expect(logger.warnings[0]).to.contain('test-agent').and.to.contain('no-such-fragment');
+    });
+
+    it('a custom agent exposes the turn prompt id through its setter', async () => {
+        const agent = new CustomChatAgent();
+        agent.turnPrompt = 'open-editors-hint';
+        const calls: string[] = [];
+        (agent as unknown as { promptService: PromptService }).promptService = {
+            getResolvedPromptFragment: async (id: string) => { calls.push(id); return { id, text: 'state' }; }
+        } as unknown as PromptService;
+
+        const resolved = await (agent as unknown as { resolveTurnPrompt(c: ChatSessionContext): Promise<ResolvedPromptFragment | undefined> })
+            .resolveTurnPrompt({ model: new MutableChatModel(ChatAgentLocation.Panel) });
+
+        expect(resolved?.text).to.equal('state');
+        expect(calls).to.deep.equal(['open-editors-hint']);
     });
 });
 
@@ -362,5 +503,93 @@ describe('AbstractChatAgent.appendExternalFileChangeNotice', () => {
         await agent.exposeAppendExternalFileChangeNotice(createRequest(), messages);
 
         expect(messages).to.be.empty;
+    });
+});
+
+describe('AbstractChatAgent.appendGenericCapabilities', () => {
+    it('merges the resolved capability fragments\' variables into the returned description', async () => {
+        const agent = new TestChatAgent();
+        const editors: ResolvedAIVariable = { variable: { id: 'openEditors', name: 'openEditors', description: '', isVolatile: true }, value: '"a.ts"' };
+        agent.setPromptService({
+            getResolvedPromptFragment: async (id: string) => id === GENERIC_CAPABILITIES_FUNCTIONS_PROMPT_ID
+                ? { id, text: 'functions text', variables: [editors] }
+                : undefined
+        } as unknown as PromptService);
+        const systemMessage: SystemMessageDescription = { text: 'base', variables: [] };
+        const context: CapabilityAwareContext = { genericCapabilitySelections: { functions: ['foo'] } };
+
+        const result = await agent.exposeAppendGenericCapabilities(systemMessage, context);
+
+        expect(result.text).to.equal('base\n\nfunctions text');
+        expect(result.variables).to.deep.equal([editors]);
+    });
+
+    it('returns the description unchanged when there are no selections', async () => {
+        const agent = new TestChatAgent();
+        const systemMessage: SystemMessageDescription = { text: 'base', variables: [] };
+
+        const result = await agent.exposeAppendGenericCapabilities(systemMessage, {});
+
+        expect(result).to.equal(systemMessage);
+    });
+});
+
+describe('AbstractChatAgent volatile system prompt warning', () => {
+    const editors: ResolvedAIVariable = { variable: { id: 'openEditors', name: 'openEditors', description: '', isVolatile: true }, value: '"a.ts"' };
+    const stable: ResolvedAIVariable = { variable: { id: 'productName', name: 'productName', description: '' }, value: 'Theia' };
+
+    it('warns once per agent and prompt variant, naming the variables', () => {
+        const agent = new TestChatAgent();
+        const logger = agent.useRecordingLogger();
+        const description: SystemMessageDescription = { text: '...', promptVariantId: 'coder-system-agent-mode', variables: [stable, editors] };
+
+        agent.exposeWarnAboutVolatileSystemPromptVariables(description);
+        agent.exposeWarnAboutVolatileSystemPromptVariables(description);
+
+        expect(logger.warnings).to.have.lengthOf(1);
+        expect(logger.warnings[0]).to.contain('test-agent').and.to.contain('coder-system-agent-mode').and.to.contain('openEditors').and.to.contain('turnPromptId');
+    });
+
+    it('warns again for a different prompt variant', () => {
+        const agent = new TestChatAgent();
+        const logger = agent.useRecordingLogger();
+
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', promptVariantId: 'variant-a', variables: [editors] });
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', promptVariantId: 'variant-b', variables: [editors] });
+
+        expect(logger.warnings).to.have.lengthOf(2);
+    });
+
+    it('falls back to systemPromptId when there is no prompt variant, and warns again for a different systemPromptId', () => {
+        const agent = new TestChatAgent();
+        const logger = agent.useRecordingLogger();
+        agent.setSystemPromptId('coder-system');
+
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', variables: [editors] });
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', variables: [editors] });
+
+        expect(logger.warnings).to.have.lengthOf(1);
+        expect(logger.warnings[0]).to.contain('test-agent').and.to.contain('coder-system').and.to.contain('openEditors');
+
+        agent.setSystemPromptId('other-system');
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', variables: [editors] });
+
+        expect(logger.warnings).to.have.lengthOf(2);
+        expect(logger.warnings[1]).to.contain('other-system');
+    });
+
+    it('stays silent without volatile variables', () => {
+        const agent = new TestChatAgent();
+        const logger = agent.useRecordingLogger();
+
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', promptVariantId: 'variant-a', variables: [stable] });
+        agent.exposeWarnAboutVolatileSystemPromptVariables({ text: '', promptVariantId: 'variant-a' });
+
+        expect(logger.warnings).to.be.empty;
+    });
+
+    it('fromResolvedPromptFragment carries the resolved variables', () => {
+        const description = SystemMessageDescription.fromResolvedPromptFragment({ id: 'x', text: 'y', variables: [editors] }, 'x', false);
+        expect(description.variables).to.deep.equal([editors]);
     });
 });

--- a/packages/ai-chat/src/common/chat-agents.spec.ts
+++ b/packages/ai-chat/src/common/chat-agents.spec.ts
@@ -200,7 +200,7 @@ describe('AbstractChatAgent turn prompt', () => {
         return messages.map(message => message.type === 'text' ? `${message.actor}:${message.text}` : message.type);
     }
 
-    it('appends a stored turn prompt to the user text of its request, in the same user message, for every request', async () => {
+    it('prepends a stored turn prompt to the user text of its request, in the same user message, for every request', async () => {
         const agent = new TestChatAgent();
         const model = new MutableChatModel(ChatAgentLocation.Panel);
         const first = model.addRequest(createParsedRequest('First'));
@@ -216,9 +216,9 @@ describe('AbstractChatAgent turn prompt', () => {
         const messages = await agent.exposeGetMessages(model);
 
         expect(summarize(messages)).to.deep.equal([
-            'user:First\n\neditors: a.ts', 'ai:Reply 1',
+            'user:editors: a.ts\n\nFirst', 'ai:Reply 1',
             'user:Second', 'ai:Reply 2',
-            'user:Third\n\neditors: b.ts'
+            'user:editors: b.ts\n\nThird'
         ]);
     });
 

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -43,6 +43,7 @@ import {
     LanguageModelService,
     LanguageModelStreamResponse,
     PromptService,
+    ResolvedAIVariable,
     ResolvedPromptFragment,
     PromptVariantSet,
     ServerToolCall,
@@ -104,6 +105,8 @@ export interface SystemMessageDescription {
     promptVariantId?: string;
     /** Whether the prompt variant is customized */
     isPromptVariantCustomized?: boolean;
+    /** The variables that were resolved while building the text (used to detect volatile ones). */
+    variables?: ResolvedAIVariable[];
 }
 export namespace SystemMessageDescription {
     export function fromResolvedPromptFragment(
@@ -116,7 +119,8 @@ export namespace SystemMessageDescription {
             functionDescriptions: resolvedPrompt.functionDescriptions,
             deferredFunctionIds: resolvedPrompt.deferredFunctionIds,
             promptVariantId,
-            isPromptVariantCustomized
+            isPromptVariantCustomized,
+            variables: resolvedPrompt.variables
         };
     }
 }
@@ -219,6 +223,18 @@ export abstract class AbstractChatAgent implements ChatAgent {
     functions: string[] = [];
     protected readonly abstract defaultLanguageModelPurpose: string;
     protected systemPromptId: string | undefined = undefined;
+    /**
+     * Optional id of a prompt fragment that is resolved on every request and appended to the user's message text
+     * instead of the system prompt. Use it for volatile state such as open editors or the current selection: the
+     * system prompt stays byte-stable across turns (so provider prompt caches keep hitting) while the model still
+     * receives the state as of each message. The resolved text is stored on the request
+     * ({@link ChatRequestModel.turnPrompt}) and replayed verbatim on later turns.
+     */
+    protected turnPromptId: string | undefined = undefined;
+    /** Prompt ids already warned about, so a chatty session logs the volatile-variable warning once. */
+    protected readonly volatileSystemPromptsWarned = new Set<string>();
+    /** Turn prompt ids already warned about, so a chatty session logs the missing-turn-prompt warning once. */
+    protected readonly missingTurnPromptsWarned = new Set<string>();
     protected additionalToolRequests: ToolRequest[] = [];
     protected contentMatchers: ResponseContentMatcher[] = [];
 
@@ -253,12 +269,19 @@ export abstract class AbstractChatAgent implements ChatAgent {
                 systemMessageDescription = await this.appendGenericCapabilities(systemMessageDescription, context);
             }
 
+            if (systemMessageDescription) {
+                this.warnAboutVolatileSystemPromptVariables(systemMessageDescription);
+            }
+
             if (systemMessageDescription?.promptVariantId) {
                 request.response.setPromptVariantInfo(
                     systemMessageDescription.promptVariantId,
                     systemMessageDescription.isPromptVariantCustomized ?? false
                 );
             }
+
+            const turnPrompt = await this.resolveTurnPrompt(context);
+            request.setTurnPrompt(turnPrompt?.text);
 
             const messages = await this.getMessages(request.session);
             await this.appendExternalFileChangeNotice(request, messages);
@@ -274,14 +297,17 @@ export abstract class AbstractChatAgent implements ChatAgent {
             }
 
             const systemMessageToolRequests = systemMessageDescription?.functionDescriptions?.values();
+            const turnPromptToolRequests = turnPrompt?.functionDescriptions?.values();
             const tools = [
                 ...this.chatToolRequestService.getChatToolRequests(request),
                 ...this.chatToolRequestService.toChatToolRequests(systemMessageToolRequests ? Array.from(systemMessageToolRequests) : [], request),
+                ...this.chatToolRequestService.toChatToolRequests(turnPromptToolRequests ? Array.from(turnPromptToolRequests) : [], request),
                 ...this.chatToolRequestService.toChatToolRequests(this.additionalToolRequests, request)
             ];
             const deferredSet = new Set<string>();
             request.message.deferredToolIds?.forEach(id => deferredSet.add(id));
             systemMessageDescription?.deferredFunctionIds?.forEach(id => deferredSet.add(id));
+            turnPrompt?.deferredFunctionIds?.forEach(id => deferredSet.add(id));
             const deferredToolIds = deferredSet.size > 0 ? Array.from(deferredSet) : undefined;
             const languageModelResponse = await this.sendLlmRequest(
                 request,
@@ -400,6 +426,55 @@ export abstract class AbstractChatAgent implements ChatAgent {
     }
 
     /**
+     * Resolves {@link turnPromptId} with the same context as the system prompt. Returns `undefined` when no turn
+     * prompt is declared or it resolves to empty text. Subclasses that compute the per-turn state in code override this.
+     *
+     * When {@link turnPromptId} is set but no prompt fragment with that id exists, logs a warning once per agent
+     * and fragment id (via {@link missingTurnPromptsWarned}) so a typo or a removed fragment is not silently dropped.
+     * Resolving to blank text stays silent: an empty turn prompt is a legitimate outcome (e.g. no editors open).
+     */
+    protected async resolveTurnPrompt(context: AIVariableContext): Promise<ResolvedPromptFragment | undefined> {
+        if (this.turnPromptId === undefined) {
+            return undefined;
+        }
+        const resolved = await this.promptService.getResolvedPromptFragment(this.turnPromptId, undefined, context);
+        if (!resolved) {
+            if (!this.missingTurnPromptsWarned.has(this.turnPromptId)) {
+                this.missingTurnPromptsWarned.add(this.turnPromptId);
+                this.logger.warn(
+                    `Agent '${this.id}' declares turn prompt '${this.turnPromptId}', but no prompt fragment with that id exists; no turn prompt is sent.`
+                );
+            }
+            return undefined;
+        }
+        return resolved.text.trim().length > 0 ? resolved : undefined;
+    }
+
+    /**
+     * Logs a warning (once per agent and prompt variant, falling back to {@link systemPromptId} when the
+     * description carries no variant id) when the resolved system prompt contains variables marked
+     * {@link AIVariable.isVolatile}: their value changes between turns, which invalidates the provider's cached
+     * prompt prefix on every request. The framework cannot prevent adopters from doing this in customized
+     * templates, so it flags it and points at {@link turnPromptId}.
+     */
+    protected warnAboutVolatileSystemPromptVariables(description: SystemMessageDescription): void {
+        const volatile = ResolvedAIVariable.findVolatile(description.variables);
+        if (volatile.length === 0) {
+            return;
+        }
+        const promptId = description.promptVariantId ?? this.systemPromptId ?? '';
+        if (this.volatileSystemPromptsWarned.has(promptId)) {
+            return;
+        }
+        this.volatileSystemPromptsWarned.add(promptId);
+        this.logger.warn(
+            `The system prompt of agent '${this.id}' (variant '${promptId || 'unknown'}') resolves the volatile variable(s) ` +
+            `${volatile.map(v => v.name).join(', ')}. Their values change between turns and defeat prompt caching for the whole conversation. ` +
+            'Deliver them per turn instead (AbstractChatAgent.turnPromptId, or `turnPrompt` in agent.md).'
+        );
+    }
+
+    /**
      * Appends resolved generic capability prompt fragments to the system message.
      * Only includes fragments for capability types that have selections.
      */
@@ -429,6 +504,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
         const resolvedTexts: string[] = [];
         let combinedFunctions = systemMessage.functionDescriptions;
         const combinedDeferred = new Set<string>(systemMessage.deferredFunctionIds ?? []);
+        let combinedVariables = systemMessage.variables;
 
         for (const resolvedFragment of resolvedResults) {
             if (resolvedFragment && resolvedFragment.text.trim()) {
@@ -449,6 +525,11 @@ export abstract class AbstractChatAgent implements ChatAgent {
                         combinedDeferred.add(id);
                     }
                 }
+                // Merge resolved variables, so a volatile variable resolved by a capability fragment is still
+                // detected by warnAboutVolatileSystemPromptVariables.
+                if (resolvedFragment.variables && resolvedFragment.variables.length > 0) {
+                    combinedVariables = [...(combinedVariables ?? []), ...resolvedFragment.variables];
+                }
             }
         }
 
@@ -462,7 +543,8 @@ export abstract class AbstractChatAgent implements ChatAgent {
             ...systemMessage,
             text: combinedText,
             functionDescriptions: combinedFunctions,
-            deferredFunctionIds: combinedDeferred.size > 0 ? combinedDeferred : undefined
+            deferredFunctionIds: combinedDeferred.size > 0 ? combinedDeferred : undefined,
+            variables: combinedVariables
         };
     }
 
@@ -471,7 +553,10 @@ export abstract class AbstractChatAgent implements ChatAgent {
     ): Promise<LanguageModelMessage[]> {
         const requestMessages = model.getRequests().flatMap(request => {
             const messages: LanguageModelMessage[] = [];
-            const text = request.message.parts.map(part => part.promptText).join('');
+            // The turn prompt shares the user's text message so that every provider sees a single user turn.
+            const text = [request.message.parts.map(part => part.promptText).join(''), request.turnPrompt]
+                .filter((part): part is string => !!part)
+                .join('\n\n');
             if (text.length > 0) {
                 messages.push({
                     actor: 'user',

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -224,7 +224,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
     protected readonly abstract defaultLanguageModelPurpose: string;
     protected systemPromptId: string | undefined = undefined;
     /**
-     * Optional id of a prompt fragment that is resolved on every request and appended to the user's message text
+     * Optional id of a prompt fragment that is resolved on every request and prepended to the user's message text
      * instead of the system prompt. Use it for volatile state such as open editors or the current selection: the
      * system prompt stays byte-stable across turns (so provider prompt caches keep hitting) while the model still
      * receives the state as of each message. The resolved text is stored on the request
@@ -554,7 +554,9 @@ export abstract class AbstractChatAgent implements ChatAgent {
         const requestMessages = model.getRequests().flatMap(request => {
             const messages: LanguageModelMessage[] = [];
             // The turn prompt shares the user's text message so that every provider sees a single user turn.
-            const text = [request.message.parts.map(part => part.promptText).join(''), request.turnPrompt]
+            // The turn prompt frames the request, and the user's own words stay the last thing the model reads
+            // (the Claude Code agent places its <ide-context> block the same way).
+            const text = [request.turnPrompt, request.message.parts.map(part => part.promptText).join('')]
                 .filter((part): part is string => !!part)
                 .join('\n\n');
             if (text.length > 0) {

--- a/packages/ai-chat/src/common/chat-model-serialization.ts
+++ b/packages/ai-chat/src/common/chat-model-serialization.ts
@@ -119,6 +119,8 @@ export interface SerializableChatRequestData {
      * Server tool selections for this request, keyed by model vendor.
      */
     serverToolSelections?: Record<string, string[]>;
+    /** Per-turn prompt text sent with this request, see `ChatRequestModel.turnPrompt`. */
+    turnPrompt?: string;
 }
 
 export interface SerializableChatResponseContentData<T = unknown> {

--- a/packages/ai-chat/src/common/chat-model.spec.ts
+++ b/packages/ai-chat/src/common/chat-model.spec.ts
@@ -15,7 +15,9 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { CompactionChatResponseContentImpl, CompactionChatResponseContent } from './chat-model';
+import { CompactionChatResponseContentImpl, CompactionChatResponseContent, MutableChatModel, MutableChatRequestModel } from './chat-model';
+import { ChatAgentLocation } from './chat-agents';
+import { ParsedChatRequestTextPart } from './parsed-chat-request';
 
 describe('CompactionChatResponseContent', () => {
     it('round-trips through serialization', () => {
@@ -38,5 +40,33 @@ describe('CompactionChatResponseContent', () => {
         expect(content.asString()).to.equal(undefined);
         expect(content.asDisplayString()).to.equal('sum');
         expect(CompactionChatResponseContent.is(content)).to.equal(true);
+    });
+});
+
+describe('MutableChatRequestModel.turnPrompt', () => {
+    function addRequest(model: MutableChatModel, text: string): MutableChatRequestModel {
+        return model.addRequest({
+            request: { text },
+            parts: [new ParsedChatRequestTextPart({ start: 0, endExclusive: text.length }, text)],
+            toolRequests: new Map(),
+            variables: []
+        });
+    }
+
+    it('is undefined until set', () => {
+        const request = addRequest(new MutableChatModel(ChatAgentLocation.Panel), 'Hello');
+        expect(request.turnPrompt).to.equal(undefined);
+        request.setTurnPrompt('## Open Editors\n"a.ts"');
+        expect(request.turnPrompt).to.equal('## Open Editors\n"a.ts"');
+        request.setTurnPrompt(undefined);
+        expect(request.turnPrompt).to.equal(undefined);
+    });
+
+    it('round-trips through session serialization', () => {
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        addRequest(model, 'First').setTurnPrompt('state 1');
+        addRequest(model, 'Second');
+        const restored = new MutableChatModel(model.toSerializable());
+        expect(restored.getRequests().map(r => r.turnPrompt)).to.deep.equal(['state 1', undefined]);
     });
 });

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -430,6 +430,13 @@ export interface ChatRequestModel {
     readonly context: ChatContext;
     readonly agentId?: string;
     readonly data?: { [key: string]: unknown };
+    /**
+     * Resolved per-turn prompt text (for example the current editor state) that the handling agent sent to the
+     * language model together with this request's message. It is replayed verbatim with the message on later
+     * turns so that the history sent to the model stays stable (see `AbstractChatAgent.turnPromptId`).
+     * `undefined` when the agent declares no turn prompt.
+     */
+    readonly turnPrompt?: string;
     toSerializable(): SerializableChatRequestData;
 }
 
@@ -1911,6 +1918,7 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
     protected _context: ChatContext;
     protected _agentId?: string;
     protected _data: { [key: string]: unknown };
+    protected _turnPrompt?: string;
     protected _isEditing = false;
     protected _message: ParsedChatRequest;
 
@@ -1979,6 +1987,7 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
             serverToolSelections: reqData.serverToolSelections
         };
         this._agentId = reqData.agentId;
+        this._turnPrompt = reqData.turnPrompt;
         this._data = {};
         this._context = { variables: [] };
 
@@ -2187,6 +2196,15 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
         return this._agentId;
     }
 
+    get turnPrompt(): string | undefined {
+        return this._turnPrompt;
+    }
+
+    /** Records the per-turn prompt text sent with this request, see {@link ChatRequestModel.turnPrompt}. */
+    setTurnPrompt(text: string | undefined): void {
+        this._turnPrompt = text;
+    }
+
     cancelEdit(): void {
         if (this.isEditing) {
             this._isEditing = false;
@@ -2227,7 +2245,8 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
             parsedRequest: this.message ? ParsedChatRequest.toSerializable(this.message) : undefined,
             capabilityOverrides: this.request.capabilityOverrides,
             genericCapabilitySelections: this.request.genericCapabilitySelections,
-            serverToolSelections: this.request.serverToolSelections
+            serverToolSelections: this.request.serverToolSelections,
+            turnPrompt: this._turnPrompt
         };
     }
 

--- a/packages/ai-chat/src/common/custom-chat-agent.ts
+++ b/packages/ai-chat/src/common/custom-chat-agent.ts
@@ -35,6 +35,11 @@ export class CustomChatAgent extends AbstractStreamParsingChatAgent {
         this.prompts.push({ id: this.systemPromptId, defaultVariant: { id: `${this.name}_prompt`, template: prompt } });
     }
 
+    /** Id of the fragment sent with every user turn, see `AbstractChatAgent.turnPromptId`. */
+    set turnPrompt(fragmentId: string | undefined) {
+        this.turnPromptId = fragmentId;
+    }
+
     /**
      * Replace the variants of this agent's prompt set with the given list. Must be called
      * AFTER {@link prompt} has been set, since it mutates the most recently pushed prompt set.

--- a/packages/ai-claude-code/src/browser/claude-code-chat-agent.spec.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-chat-agent.spec.ts
@@ -1,0 +1,113 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+import 'reflect-metadata';
+import { expect } from 'chai';
+import { MutableChatRequestModel } from '@theia/ai-chat';
+import { PromptService, ResolvedPromptFragment } from '@theia/ai-core';
+import { ClaudeCodeChatAgent, ideContextTemplate, systemPromptAppendixTemplate } from './claude-code-chat-agent';
+disableJSDOM();
+
+/** Substitutes `{{name}}` from args, `{{selectedText}}` with a fixed value, so the wiring (not PromptService) is under test. */
+class FakePromptService {
+    readonly templates = new Map<string, string>([
+        [systemPromptAppendixTemplate.id, systemPromptAppendixTemplate.template],
+        [ideContextTemplate.id, ideContextTemplate.template]
+    ]);
+    async getResolvedPromptFragment(id: string, args?: Record<string, unknown>): Promise<ResolvedPromptFragment | undefined> {
+        let text = this.templates.get(id);
+        if (text === undefined) {
+            return undefined;
+        }
+        text = text.replace('{{selectedText}}', 'SELECTED').replace('{{productName}}', 'Theia');
+        for (const [key, value] of Object.entries(args ?? {})) {
+            text = text.replace(`{{${key}}}`, String(value));
+        }
+        return { id, text };
+    }
+}
+
+class TestableClaudeCodeChatAgent extends ClaudeCodeChatAgent {
+    constructor() {
+        super();
+        this.promptService = new FakePromptService() as unknown as PromptService;
+        (this as unknown as { editorManager: unknown }).editorManager = {
+            currentEditor: { editor: { document: { uri: 'file:///ws/active.ts' } } },
+            all: [{ editor: { document: { uri: 'file:///ws/active.ts' } } }, { editor: { document: { uri: 'file:///ws/other.ts' } } }]
+        };
+    }
+    exposeCreateIdeContext(request: MutableChatRequestModel): Promise<ResolvedPromptFragment | undefined> {
+        return this.createIdeContext(request, this.collectIdeContextArgs(request));
+    }
+    exposeCreateSystemPromptAppendix(request: MutableChatRequestModel): Promise<ResolvedPromptFragment | undefined> {
+        return this.createSystemPromptAppendix(request, this.collectIdeContextArgs(request));
+    }
+    exposeBuildPrompt(request: MutableChatRequestModel, ideContext: ResolvedPromptFragment | undefined): string {
+        return this.buildPrompt(request, ideContext);
+    }
+    setAppendixTemplate(text: string): void {
+        (this.promptService as unknown as FakePromptService).templates.set(systemPromptAppendixTemplate.id, text);
+    }
+}
+
+function fakeRequest(text: string): MutableChatRequestModel {
+    return {
+        request: { text },
+        context: { variables: [{ variable: { id: 'file', name: 'file', description: '' }, arg: 'src/a.ts', value: '', contextValue: '' }] },
+        session: { context: { getVariables: () => [] } }
+    } as unknown as MutableChatRequestModel;
+}
+
+describe('ClaudeCodeChatAgent IDE context', () => {
+    let agent: TestableClaudeCodeChatAgent;
+    beforeEach(() => { agent = new TestableClaudeCodeChatAgent(); });
+
+    it('keeps the system prompt appendix free of volatile editor state', async () => {
+        const appendix = await agent.exposeCreateSystemPromptAppendix(fakeRequest('hi'));
+        expect(appendix?.text).to.contain('IDE Integration Context').and.to.contain('<ide-context>');
+        for (const volatile of ['SELECTED', 'file:///ws/active.ts', 'file:///ws/other.ts', 'src/a.ts', '{{']) {
+            expect(appendix?.text).not.to.contain(volatile);
+        }
+    });
+
+    it('resolves the per-turn ide-context block with selection, active editor, open editors and context files', async () => {
+        const ideContext = await agent.exposeCreateIdeContext(fakeRequest('hi'));
+        expect(ideContext?.text.trim().startsWith('<ide-context>')).to.equal(true);
+        expect(ideContext?.text.trim().endsWith('</ide-context>')).to.equal(true);
+        expect(ideContext?.text).to.contain('SELECTED').and.to.contain('file:///ws/active.ts').and.to.contain('- file:///ws/other.ts').and.to.contain('- src/a.ts');
+        // State only: the usage guidance stays in the stable appendix.
+        expect(ideContext?.text).not.to.contain('prioritize');
+    });
+
+    it('still resolves an adopter-customized appendix that keeps a volatile placeholder like {{activeEditor}}', async () => {
+        agent.setAppendixTemplate(systemPromptAppendixTemplate.template + '\n{{activeEditor}}');
+
+        const appendix = await agent.exposeCreateSystemPromptAppendix(fakeRequest('hi'));
+
+        expect(appendix?.text).to.contain('file:///ws/active.ts');
+        expect(appendix?.text).not.to.contain('{{activeEditor}}');
+    });
+
+    it('prepends the block to the user prompt after stripping the agent mention', () => {
+        const prompt = agent.exposeBuildPrompt(fakeRequest('@ClaudeCode fix it'), { id: ideContextTemplate.id, text: '<ide-context>x</ide-context>' });
+        expect(prompt).to.equal('<ide-context>x</ide-context>\n\nfix it');
+        expect(agent.exposeBuildPrompt(fakeRequest('fix it'), undefined)).to.equal('fix it');
+    });
+});

--- a/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
@@ -90,34 +90,14 @@ When making file modifications:
 
 ### Contextual Information Available
 
-The following IDE context is dynamically provided with each request.
-Evaluate the relevance of each context type based on the user's specific query and task requirements.
+The current IDE state — selection, active editor, open editors and attached context files — is provided at the
+start of each user message inside an \`<ide-context>\` block. It is accurate as of that message; later messages
+carry their own block. Evaluate the relevance of each part based on the user's specific query and task requirements:
 
-#### Current Selection
-
-\`\`\`
-{{selectedText}}
-\`\`\`
-
-**When to prioritize**: User asks about specific code segments, wants to refactor selected code, or requests explanations of selected text.
-
-#### Active Editor
-
-{{activeEditor}}
-
-**When to prioritize**: User's request relates to the currently focused file, asks questions about the code, or needs context about the current working file.
-
-#### Open Editors
-
-{{openEditors}}
-
-**How to use it**: As a guidance on what files might be relevant for the current user's request.
-
-#### Context Files
-
-{{contextFiles}}
-
-**When to prioritize**: User explicitly references attached files or when additional files are needed to understand the full scope of the request.
+- **Current Selection**: prioritize when the user asks about specific code segments, wants to refactor selected code, or requests explanations of selected text.
+- **Active Editor**: prioritize when the request relates to the currently focused file, asks questions about the code, or needs context about the current working file.
+- **Open Editors**: a guidance on what files might be relevant for the current user's request.
+- **Context Files**: prioritize when the user explicitly references attached files or when additional files are needed to understand the full scope of the request.
 
 ### Context Utilization Guidelines
 
@@ -137,6 +117,40 @@ Use the collective context to understand the user's current workspace state and 
 - Leverage open editors to suggest related modifications across the workspace
 `
 };
+
+/**
+ * Volatile IDE state, resolved per request and prepended to the user prompt (not the system prompt) so that the
+ * cached Claude Code system prompt and the resumed session prefix stay stable across turns. State only: the guidance
+ * on how to use it lives in the stable {@link systemPromptAppendixTemplate}.
+ */
+export const ideContextTemplate: BasePromptFragment = {
+    id: 'claude-code-ide-context',
+    template: `<ide-context>
+The following IDE state is current as of this message.
+
+#### Current Selection
+
+\`\`\`
+{{selectedText}}
+\`\`\`
+
+#### Active Editor
+
+{{activeEditor}}
+
+#### Open Editors
+
+{{openEditors}}
+
+#### Context Files
+
+{{contextFiles}}
+</ide-context>`
+};
+
+/** The volatile IDE state resolved into {@link ideContextTemplate}. */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type IdeContextArgs = { contextFiles: string; activeEditor: string; openEditors: string };
 
 export const CLAUDE_CHAT_AGENT_ID = 'ClaudeCode';
 
@@ -163,7 +177,10 @@ export class ClaudeCodeChatAgent implements ChatAgent {
     ];
 
     variables = [];
-    prompts = [{ id: systemPromptAppendixTemplate.id, defaultVariant: systemPromptAppendixTemplate }];
+    prompts = [
+        { id: systemPromptAppendixTemplate.id, defaultVariant: systemPromptAppendixTemplate },
+        { id: ideContextTemplate.id, defaultVariant: ideContextTemplate }
+    ];
     languageModelRequirements = [];
     agentSpecificVariables = [
         {
@@ -226,13 +243,11 @@ export class ClaudeCodeChatAgent implements ChatAgent {
         }
 
         try {
-            const systemPromptAppendix = await this.createSystemPromptAppendix(request);
+            const ideContextArgs = this.collectIdeContextArgs(request);
+            const systemPromptAppendix = await this.createSystemPromptAppendix(request, ideContextArgs);
+            const ideContext = await this.createIdeContext(request, ideContextArgs);
             const claudeSessionId = this.getPreviousClaudeSessionId(request);
-            const agentAddress = `${PromptText.AGENT_CHAR}${CLAUDE_CHAT_AGENT_ID}`;
-            let prompt = request.request.text.trim();
-            if (prompt.startsWith(agentAddress)) {
-                prompt = prompt.replace(agentAddress, '').trim();
-            }
+            const prompt = this.buildPrompt(request, ideContext);
 
             const shouldFork = claudeSessionId !== undefined && this.isEditRequest(request);
 
@@ -291,21 +306,40 @@ export class ClaudeCodeChatAgent implements ChatAgent {
         }
     }
 
-    protected async createSystemPromptAppendix(request: MutableChatRequestModel): Promise<ResolvedPromptFragment | undefined> {
-        const contextVariables = request.context.variables.map(AIVariableResolutionRequest.fromResolved) ?? request.session.context.getVariables();
+    /**
+     * Collects the volatile IDE state once per request. Both fragments receive it, so a customized appendix that
+     * still uses a placeholder like `{{activeEditor}}` keeps resolving.
+     */
+    protected collectIdeContextArgs(request: MutableChatRequestModel): IdeContextArgs {
+        const contextVariables = request.context.variables.map(AIVariableResolutionRequest.fromResolved);
         const contextFiles = contextVariables
             .filter(variable => variable.variable.name === 'file' && !!variable.arg)
             .map(variable => `- ${variable.arg}`)
             .join('\n');
-
         const activeEditor = this.editorManager.currentEditor?.editor.document.uri ?? 'None';
         const openEditors = this.editorManager.all.map(editor => `- ${editor.editor.document.uri}`).join('\n');
+        return { contextFiles, activeEditor, openEditors };
+    }
 
-        return this.promptService.getResolvedPromptFragment(
-            systemPromptAppendixTemplate.id,
-            { contextFiles, activeEditor, openEditors },
-            { model: request.session, request }
-        );
+    /** The stable appendix to Claude Code's system prompt. Must not contain per-request state (see {@link createIdeContext}). */
+    protected async createSystemPromptAppendix(request: MutableChatRequestModel, ideContextArgs: IdeContextArgs): Promise<ResolvedPromptFragment | undefined> {
+        return this.promptService.getResolvedPromptFragment(systemPromptAppendixTemplate.id, ideContextArgs, { model: request.session, request });
+    }
+
+    /** The volatile IDE state for this request, sent inside the user turn. */
+    protected async createIdeContext(request: MutableChatRequestModel, ideContextArgs: IdeContextArgs): Promise<ResolvedPromptFragment | undefined> {
+        return this.promptService.getResolvedPromptFragment(ideContextTemplate.id, ideContextArgs, { model: request.session, request });
+    }
+
+    /** The user's text with the agent mention stripped, preceded by the IDE context block when there is one. */
+    protected buildPrompt(request: MutableChatRequestModel, ideContext: ResolvedPromptFragment | undefined): string {
+        const agentAddress = `${PromptText.AGENT_CHAR}${CLAUDE_CHAT_AGENT_ID}`;
+        let prompt = request.request.text.trim();
+        if (prompt.startsWith(agentAddress)) {
+            prompt = prompt.replace(agentAddress, '').trim();
+        }
+        const block = ideContext?.text.trim();
+        return block ? `${block}\n\n${prompt}` : prompt;
     }
 
     protected initializesEditToolUses(request: MutableChatRequestModel): void {

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
@@ -534,7 +534,7 @@ describe('DefaultPromptFragmentCustomizationService - customAgents.yml migration
 
     const agents = [
         { id: 'foo', name: 'Foo', description: 'Foo agent', prompt: 'Foo prompt', defaultLLM: 'default/universal' },
-        { id: 'bar', name: 'Bar', description: 'Bar agent', prompt: 'Bar prompt', defaultLLM: 'default/universal' }
+        { id: 'bar', name: 'Bar', description: 'Bar agent', prompt: 'Bar prompt', defaultLLM: 'default/universal', turnPrompt: 'open-editors-hint' }
     ];
 
     let fileService: FakeFileService;
@@ -570,6 +570,10 @@ describe('DefaultPromptFragmentCustomizationService - customAgents.yml migration
         // The yaml is renamed to .bak rather than deleted.
         expect(await fileService.exists(yamlURI)).to.be.false;
         expect(await fileService.exists(backupURI)).to.be.true;
+        // 'bar' declares turnPrompt in the legacy yaml; the migrated agent.md carries it over.
+        expect(fileService.content(agentMd('bar'))).to.contain('turnPrompt: open-editors-hint');
+        // 'foo' declares no turnPrompt, so the migrated agent.md emits no such line.
+        expect(fileService.content(agentMd('foo'))).to.not.contain('turnPrompt');
     });
 
     it('rerun after a successful migration is a no-op', async () => {
@@ -766,8 +770,8 @@ describe('DefaultPromptFragmentCustomizationService - custom agent scopes', () =
     }
 
     const agentMd = (scope: URI, id: string): URI => scope.resolve(CUSTOM_AGENTS_DIRECTORY).resolve(id).resolve(CUSTOM_AGENT_FILE_NAME);
-    const agentFile = (name: string, description: string): string =>
-        `---\nname: ${name}\ndescription: ${description}\ndefaultLLM: default/universal\n---\n${name} prompt`;
+    const agentFile = (name: string, description: string, extraFrontmatter = ''): string =>
+        `---\nname: ${name}\ndescription: ${description}\ndefaultLLM: default/universal\n${extraFrontmatter}---\n${name} prompt`;
 
     let fileService: FakeFileService;
     let service: AgentScopeTestService;
@@ -809,6 +813,24 @@ describe('DefaultPromptFragmentCustomizationService - custom agent scopes', () =
 
         expect(agents).to.have.lengthOf(1);
         expect(agents[0].description).to.equal('agents version');
+    });
+
+    it('reads the optional turnPrompt frontmatter key', async () => {
+        service.setCustomAgentDirs(['/ws/.agents']);
+        fileService.write(agentMd(new URI('file:///ws/.agents'), 'foo'), agentFile('Foo', 'Foo agent', 'turnPrompt: open-editors-hint\n'));
+
+        const agents = await service.getCustomAgents();
+
+        expect(agents[0].turnPrompt).to.equal('open-editors-hint');
+    });
+
+    it('rejects an agent whose turnPrompt is not a string', async () => {
+        service.setCustomAgentDirs(['/ws/.agents']);
+        fileService.write(agentMd(new URI('file:///ws/.agents'), 'foo'), agentFile('Foo', 'Foo agent', 'turnPrompt: [a, b]\n'));
+
+        const agents = await service.getCustomAgents();
+
+        expect(agents).to.be.empty;
     });
 });
 

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -66,6 +66,8 @@ interface CustomAgentFrontmatter {
     description: string;
     defaultLLM: string;
     showInChat?: boolean;
+    /** Optional fragment id sent with every user turn instead of the system prompt, see `CustomAgentDescription.turnPrompt`. */
+    turnPrompt?: string;
     /** Allowed but ignored when present; if set, must match the folder name. */
     id?: string;
 }
@@ -80,6 +82,9 @@ namespace CustomAgentFrontmatter {
             return false;
         }
         if ('showInChat' in entry && typeof entry.showInChat !== 'boolean') {
+            return false;
+        }
+        if ('turnPrompt' in entry && typeof entry.turnPrompt !== 'string') {
             return false;
         }
         if ('id' in entry && typeof entry.id !== 'string') {
@@ -1538,6 +1543,7 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
             prompt: body,
             defaultLLM: metadata.defaultLLM,
             showInChat: metadata.showInChat,
+            turnPrompt: metadata.turnPrompt,
             ...(promptVariants.length > 0 ? { promptVariants } : {})
         };
     }
@@ -2069,6 +2075,9 @@ function serializeCustomAgentFile(agent: CustomAgentDescription): string {
     };
     if (agent.showInChat !== undefined) {
         metadata.showInChat = agent.showInChat;
+    }
+    if (agent.turnPrompt !== undefined) {
+        metadata.turnPrompt = agent.turnPrompt;
     }
     return serializeFrontmatter(metadata, agent.prompt);
 }

--- a/packages/ai-core/src/browser/open-editors-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/open-editors-variable-contribution.spec.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { NO_OPEN_EDITORS_VALUE, OPEN_EDITORS_SHORT_VARIABLE, OPEN_EDITORS_VARIABLE, OpenEditorsVariableContribution } from './open-editors-variable-contribution';
+
+disableJSDOM();
+
+describe('OpenEditorsVariableContribution', () => {
+    before(() => {
+        disableJSDOM = enableJSDOM();
+        FrontendApplicationConfigProvider.set({});
+    });
+    after(() => disableJSDOM());
+
+    /** A contribution that sees the given rendered list of open files. */
+    function contribution(openFiles: string): OpenEditorsVariableContribution {
+        const instance = new OpenEditorsVariableContribution();
+        Object.assign(instance, { getAllOpenFilesRelative: () => openFiles });
+        return instance;
+    }
+
+    it('resolves to the list of open files', async () => {
+        const result = await contribution("'src/a.ts', 'src/b.ts'").resolve({ variable: OPEN_EDITORS_VARIABLE }, {});
+        expect(result?.value).to.equal("'src/a.ts', 'src/b.ts'");
+    });
+
+    it('resolves to an explicit marker when no editor is open, for both variable names', async () => {
+        for (const variable of [OPEN_EDITORS_VARIABLE, OPEN_EDITORS_SHORT_VARIABLE]) {
+            const result = await contribution('').resolve({ variable }, {});
+            expect(result?.value, variable.name).to.equal(NO_OPEN_EDITORS_VALUE);
+        }
+    });
+
+    it('resolves nothing for other variables', async () => {
+        const result = await contribution("'src/a.ts'").resolve({ variable: { id: 'other', name: 'other', description: '' } }, {});
+        expect(result).to.be.undefined;
+    });
+});

--- a/packages/ai-core/src/browser/open-editors-variable-contribution.ts
+++ b/packages/ai-core/src/browser/open-editors-variable-contribution.ts
@@ -26,12 +26,14 @@ export const OPEN_EDITORS_VARIABLE: AIVariable = {
     description: nls.localize('theia/ai/core/openEditorsVariable/description',
         'A comma-separated list of all currently open files as workspace-relative paths (e.g., my-project/src/index.ts).'),
     name: 'openEditors',
+    isVolatile: true,
 };
 
 export const OPEN_EDITORS_SHORT_VARIABLE: AIVariable = {
     id: 'openEditorsShort',
     description: nls.localize('theia/ai/core/openEditorsShortVariable/description', 'Short reference to all currently open files (relative paths, comma-separated)'),
     name: '_ff',
+    isVolatile: true,
 };
 
 @injectable()

--- a/packages/ai-core/src/browser/open-editors-variable-contribution.ts
+++ b/packages/ai-core/src/browser/open-editors-variable-contribution.ts
@@ -36,6 +36,9 @@ export const OPEN_EDITORS_SHORT_VARIABLE: AIVariable = {
     isVolatile: true,
 };
 
+/** Value of the open-editors variables when no editor is open, so prompts render an explicit marker instead of an empty list. */
+export const NO_OPEN_EDITORS_VALUE = 'none';
+
 @injectable()
 export class OpenEditorsVariableContribution implements AIVariableContribution, AIVariableResolver {
 
@@ -62,7 +65,7 @@ export class OpenEditorsVariableContribution implements AIVariableContribution, 
         const openFiles = this.getAllOpenFilesRelative();
         return {
             variable: request.variable,
-            value: openFiles
+            value: openFiles.length > 0 ? openFiles : NO_OPEN_EDITORS_VALUE
         };
     }
 

--- a/packages/ai-core/src/browser/theia-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.spec.ts
@@ -1,0 +1,71 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({ applicationName: 'Test IDE' });
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { TheiaVariableContribution } from './theia-variable-contribution';
+
+disableJSDOM();
+
+describe('TheiaVariableContribution', () => {
+    before(() => {
+        disableJSDOM = enableJSDOM();
+        FrontendApplicationConfigProvider.set({ applicationName: 'Test IDE' });
+    });
+    after(() => disableJSDOM());
+
+    const relativeFile = { id: 'theia-relativeFile', name: 'currentRelativeFilePath', description: '' };
+
+    /** A contribution whose variable resolver returns `value` for every reference, or leaves the reference verbatim when `value` is undefined. */
+    function contribution(value: string | undefined): TheiaVariableContribution {
+        const instance = new TheiaVariableContribution();
+        Object.assign(instance, {
+            variableResolverService: {
+                resolve: async (text: string) => value === undefined ? text : value
+            }
+        });
+        return instance;
+    }
+
+    it('resolves to the value of the underlying Theia variable', async () => {
+        const result = await contribution('src/index.ts').resolve({ variable: relativeFile }, {});
+        expect(result).to.deep.equal({ value: 'src/index.ts', variable: relativeFile });
+    });
+
+    it('resolves to an empty value when the Theia variable has no value and the reference is left verbatim (no active editor)', async () => {
+        const result = await contribution(undefined).resolve({ variable: relativeFile }, {});
+        expect(result).to.deep.equal({ value: '', variable: relativeFile });
+    });
+
+    it('resolves a reference with an argument to an empty value when it is left verbatim', async () => {
+        const result = await contribution(undefined).resolve({ variable: { id: 'theia-file', name: 'currentAbsoluteFilePath', description: '' }, arg: 'x' }, {});
+        expect(result?.value).to.equal('');
+    });
+
+    it('resolves to nothing when the variable resolver returns nothing', async () => {
+        const instance = new TheiaVariableContribution();
+        Object.assign(instance, { variableResolverService: { resolve: async () => undefined } });
+        expect(await instance.resolve({ variable: relativeFile }, {})).to.be.undefined;
+    });
+});

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -26,6 +26,8 @@ import { AIVariableContribution, AIVariableResolver, AIVariableService, AIVariab
 interface VariableMapping {
     name?: string;
     description?: string;
+    /** See {@link AIVariable.isVolatile}. */
+    isVolatile?: boolean;
 }
 
 /**
@@ -52,42 +54,48 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
             {
                 name: 'currentAbsoluteFilePath',
                 description: nls.localize('theia/ai/core/variable-contribution/currentAbsoluteFilePath',
-                    'The absolute path of the currently opened file.')
+                    'The absolute path of the currently opened file.'),
+                isVolatile: true
             }
         ]],
         ['selectedText', [
             {
                 description: nls.localize('theia/ai/core/variable-contribution/currentSelectedText',
-                    'The plain text that is currently selected in the opened file. This excludes the information where the content is coming from.')
+                    'The plain text that is currently selected in the opened file. This excludes the information where the content is coming from.'),
+                isVolatile: true
             }
         ]],
         ['currentText', [
             {
                 name: 'currentFileContent',
                 description: nls.localize('theia/ai/core/variable-contribution/currentFileContent',
-                    'The plain content of the currently opened file. This excludes the information where the content is coming from.')
+                    'The plain content of the currently opened file. This excludes the information where the content is coming from.'),
+                isVolatile: true
             }
         ]],
         ['relativeFile', [
             {
                 name: 'currentRelativeFilePath',
                 description: nls.localize('theia/ai/core/variable-contribution/currentRelativeFilePath',
-                    'The workspace-relative path of the currently opened file (e.g., my-project/src/index.ts).')
+                    'The workspace-relative path of the currently opened file (e.g., my-project/src/index.ts).'),
+                isVolatile: true
             },
             {
                 name: '_f',
                 description: nls.localize('theia/ai/core/variable-contribution/dotRelativePath',
-                    'Short reference to the workspace-relative path of the currently opened file (\'currentRelativeFilePath\').')
+                    'Short reference to the workspace-relative path of the currently opened file (\'currentRelativeFilePath\').'),
+                isVolatile: true
             }
         ]],
         ['relativeFileDirname', [
             {
                 name: 'currentRelativeDirPath',
                 description: nls.localize('theia/ai/core/variable-contribution/currentRelativeDirPath',
-                    'The workspace-relative path of the directory containing the currently opened file (e.g., my-project/src).')
+                    'The workspace-relative path of the directory containing the currently opened file (e.g., my-project/src).'),
+                isVolatile: true
             }
         ]],
-        ['lineNumber', [{}]],
+        ['lineNumber', [{ isVolatile: true }]],
         ['workspaceFolder', [{}]]
     ]);
 
@@ -118,7 +126,8 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
                     service.registerResolver({
                         id,
                         name: newName,
-                        description: newDescription
+                        description: newDescription,
+                        isVolatile: mapping.isVolatile
                     }, this);
                 });
             });

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -157,7 +157,14 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
     }
 
     async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
-        const resolved = await this.variableResolverService.resolve(this.toTheiaVariable(request), context);
-        return resolved ? { value: resolved, variable: request.variable } : undefined;
+        const theiaVariable = this.toTheiaVariable(request);
+        const resolved = await this.variableResolverService.resolve(theiaVariable, context);
+        if (!resolved) {
+            return undefined;
+        }
+        // The variable resolver leaves a `${...}` reference verbatim when the Theia variable has no value in this
+        // context (e.g. `${relativeFile}` without an active editor). Resolve to an empty value instead of leaking
+        // the reference into the prompt.
+        return { value: resolved === theiaVariable ? '' : resolved, variable: request.variable };
     }
 }

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -712,3 +712,19 @@ describe('PromptService variable arguments', () => {
         expect(prompt?.text).to.equal('Read arg=undefined');
     });
 });
+
+describe('CustomAgentDescription turnPrompt', () => {
+    const base = { id: 'foo', name: 'Foo', description: 'd', prompt: 'p', defaultLLM: 'default/universal' };
+
+    it('accepts an absent or string turnPrompt and rejects other types', () => {
+        expect(CustomAgentDescription.is(base)).to.equal(true);
+        expect(CustomAgentDescription.is({ ...base, turnPrompt: 'open-editors-hint' })).to.equal(true);
+        expect(CustomAgentDescription.is({ ...base, turnPrompt: 42 })).to.equal(false);
+    });
+
+    it('takes turnPrompt into account for equality', () => {
+        expect(CustomAgentDescription.equals({ ...base, turnPrompt: 'a' }, { ...base, turnPrompt: 'a' })).to.equal(true);
+        expect(CustomAgentDescription.equals({ ...base, turnPrompt: 'a' }, { ...base, turnPrompt: 'b' })).to.equal(false);
+        expect(CustomAgentDescription.equals({ ...base, turnPrompt: 'a' }, base)).to.equal(false);
+    });
+});

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -186,6 +186,12 @@ export interface CustomAgentDescription {
     showInChat?: boolean;
 
     /**
+     * Optional id of a prompt fragment sent inside every user turn instead of the system prompt (e.g.
+     * `open-editors-hint`). Use it for volatile editor state so the system prompt stays cacheable.
+     */
+    turnPrompt?: string;
+
+    /**
      * Optional additional prompt variants for this agent. Loaded from sibling
      * `.prompttemplate` files in the same `<scope>/agents/<id>/` folder.
      */
@@ -219,6 +225,9 @@ export namespace CustomAgentDescription {
         if ('showInChat' in entry && typeof entry.showInChat !== 'boolean') {
             return false;
         }
+        if ('turnPrompt' in entry && typeof entry.turnPrompt !== 'string') {
+            return false;
+        }
         return true;
     }
 
@@ -232,6 +241,7 @@ export namespace CustomAgentDescription {
             && a.prompt === b.prompt
             && a.defaultLLM === b.defaultLLM
             && a.showInChat === b.showInChat
+            && a.turnPrompt === b.turnPrompt
             && CustomAgentPromptVariant.arrayEquals(a.promptVariants, b.promptVariants);
     }
 }

--- a/packages/ai-core/src/common/variable-service.spec.ts
+++ b/packages/ai-core/src/common/variable-service.spec.ts
@@ -317,3 +317,30 @@ describe('DefaultAIVariableService', () => {
         });
     });
 });
+
+describe('ResolvedAIVariable.findVolatile', () => {
+    const stable: AIVariable = { id: 'p.stable', name: 'stable', description: 'stable' };
+    const editors: AIVariable = { id: 'openEditors', name: 'openEditors', description: 'open editors', isVolatile: true };
+    const selection: AIVariable = { id: 'theia-selectedText', name: 'selectedText', description: 'selection', isVolatile: true };
+
+    it('returns nothing for undefined or non-volatile variables', () => {
+        expect(ResolvedAIVariable.findVolatile(undefined)).to.deep.equal([]);
+        expect(ResolvedAIVariable.findVolatile([{ variable: stable, value: 'x' }])).to.deep.equal([]);
+    });
+
+    it('returns each volatile variable once, including nested dependencies', () => {
+        const nested: ResolvedAIVariable = {
+            variable: { id: 'prompt', name: 'prompt', description: 'nested fragment' },
+            arg: 'open-editors-hint',
+            value: '...',
+            allResolvedDependencies: [{ variable: editors, value: '"a.ts"' }]
+        };
+        const result = ResolvedAIVariable.findVolatile([
+            { variable: stable, value: 'x' },
+            nested,
+            { variable: editors, value: '"a.ts"' },
+            { variable: selection, value: 'foo' }
+        ]);
+        expect(result.map(v => v.name)).to.deep.equal(['openEditors', 'selectedText']);
+    });
+});

--- a/packages/ai-core/src/common/variable-service.ts
+++ b/packages/ai-core/src/common/variable-service.ts
@@ -42,6 +42,13 @@ export interface AIVariable {
     isContextVariable?: boolean;
     /** optional arguments for resolving the variable into a value */
     args?: AIVariableDescription[];
+    /**
+     * Set when the value reflects transient UI state that can change between chat turns without any action
+     * directed at the chat (active editor, selection, open tabs). Resolving such a variable into a system prompt
+     * changes the prompt on every turn and defeats provider prompt caching; agents should deliver it per turn
+     * instead (see `AbstractChatAgent.turnPromptId` in `@theia/ai-chat`).
+     */
+    isVolatile?: boolean;
 }
 
 export namespace AIVariable {
@@ -87,6 +94,27 @@ export namespace ResolvedAIVariable {
             'value' in arg &&
             typeof (arg as { variable: unknown }).variable === 'object' &&
             typeof (arg as { value: unknown }).value === 'string';
+    }
+
+    /**
+     * Returns the distinct volatile variables (see {@link AIVariable.isVolatile}) among the given resolved
+     * variables, including their recursively resolved dependencies.
+     */
+    export function findVolatile(variables: readonly ResolvedAIVariable[] | undefined): AIVariable[] {
+        const found = new Map<string, AIVariable>();
+        const seen = new Set<ResolvedAIVariable>();
+        const visit = (resolved: ResolvedAIVariable): void => {
+            if (seen.has(resolved)) {
+                return;
+            }
+            seen.add(resolved);
+            if (resolved.variable.isVolatile) {
+                found.set(resolved.variable.name, resolved.variable);
+            }
+            resolved.allResolvedDependencies?.forEach(visit);
+        };
+        variables?.forEach(visit);
+        return Array.from(found.values());
     }
 }
 

--- a/packages/ai-core/src/common/variable-service.ts
+++ b/packages/ai-core/src/common/variable-service.ts
@@ -43,10 +43,10 @@ export interface AIVariable {
     /** optional arguments for resolving the variable into a value */
     args?: AIVariableDescription[];
     /**
-     * Set when the value reflects transient UI state that can change between chat turns without any action
-     * directed at the chat (active editor, selection, open tabs). Resolving such a variable into a system prompt
-     * changes the prompt on every turn and defeats provider prompt caching; agents should deliver it per turn
-     * instead (see `AbstractChatAgent.turnPromptId` in `@theia/ai-chat`).
+     * Set when the value can change from one chat turn to the next: transient UI state (active editor, selection,
+     * open tabs) as well as chat context that evolves with the conversation (attached files, the change set).
+     * Resolving such a variable into a system prompt changes the prompt on every turn and defeats provider prompt
+     * caching; agents should deliver it per turn instead (see `AbstractChatAgent.turnPromptId` in `@theia/ai-chat`).
      */
     isVolatile?: boolean;
 }

--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -27,6 +27,7 @@ import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { AI_EXECUTE_PLAN_WITH_CODER } from '../common/summarize-session-commands';
 import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
 import { ArchitectAgentId } from '../common/agent-ids';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
 
 export { ArchitectAgentId };
 
@@ -70,6 +71,7 @@ export class ArchitectAgent extends AbstractModeAwareChatAgent {
 
     override prompts = [architectSystemVariants];
     protected override systemPromptId: string | undefined = architectSystemVariants.id;
+    protected override turnPromptId: string | undefined = OPEN_EDITORS_HINT_FRAGMENT_ID;
 
     override async invoke(request: MutableChatRequestModel): Promise<void> {
         await super.invoke(request);

--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -27,7 +27,7 @@ import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { AI_EXECUTE_PLAN_WITH_CODER } from '../common/summarize-session-commands';
 import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
 import { ArchitectAgentId } from '../common/agent-ids';
-import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
+import { ARCHITECT_TURN_PROMPT_ID } from '../common/turn-prompt-fragment-ids';
 
 export { ArchitectAgentId };
 
@@ -71,7 +71,7 @@ export class ArchitectAgent extends AbstractModeAwareChatAgent {
 
     override prompts = [architectSystemVariants];
     protected override systemPromptId: string | undefined = architectSystemVariants.id;
-    protected override turnPromptId: string | undefined = OPEN_EDITORS_HINT_FRAGMENT_ID;
+    protected override turnPromptId: string | undefined = ARCHITECT_TURN_PROMPT_ID;
 
     override async invoke(request: MutableChatRequestModel): Promise<void> {
         await super.invoke(request);

--- a/packages/ai-ide/src/browser/architect-prompt-template.ts
+++ b/packages/ai-ide/src/browser/architect-prompt-template.ts
@@ -19,7 +19,6 @@ import {
   GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID, FIND_FILES_BY_PATTERN_FUNCTION_ID
 } from '../common/workspace-functions';
 import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from '../common/context-variables';
-import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
 import {
   CREATE_TASK_CONTEXT_FUNCTION_ID,
   GET_TASK_CONTEXT_FUNCTION_ID,
@@ -195,8 +194,6 @@ When a diagram clarifies an architectural concept or how something is implemente
 
 {{prompt:project-info}}
 
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
-
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `
   },
@@ -234,8 +231,6 @@ Always look at the relevant files to understand your task using the function ~{$
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
-
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 `
     },
     {
@@ -468,8 +463,6 @@ When a diagram clarifies an architectural concept or how something is implemente
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
-
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `

--- a/packages/ai-ide/src/browser/architect-prompt-template.ts
+++ b/packages/ai-ide/src/browser/architect-prompt-template.ts
@@ -18,7 +18,7 @@ import { PromptVariantSet } from '@theia/ai-core/lib/common';
 import {
   GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID, FIND_FILES_BY_PATTERN_FUNCTION_ID
 } from '../common/workspace-functions';
-import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from '../common/context-variables';
+import { TASK_CONTEXT_SUMMARY_VARIABLE_ID } from '../common/context-variables';
 import {
   CREATE_TASK_CONTEXT_FUNCTION_ID,
   GET_TASK_CONTEXT_FUNCTION_ID,
@@ -190,8 +190,6 @@ When a diagram clarifies an architectural concept or how something is implemente
 
 # Context
 
-{{${CONTEXT_FILES_VARIABLE_ID}}}
-
 {{prompt:project-info}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
@@ -224,11 +222,6 @@ Use the following functions to interact with the workspace files as needed:
 ## Diagrams
 
 When a diagram clarifies an architectural concept or how something is implemented, include a Mermaid diagram (a fenced \`mermaid\` code block). It is rendered directly in the chat. Keep diagrams small and focused. The chat has limited space, so prefer a few simple diagrams over a single large, complex one.
-
-## Additional Context
-The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). \
-Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
-{{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
 `
@@ -459,8 +452,6 @@ When editing a plan:
 When a diagram clarifies an architectural concept or how something is implemented, include a Mermaid diagram (a fenced \`mermaid\` code block) in your chat response. It is rendered directly in the chat. Keep diagrams small and focused. The chat has limited space, so prefer a few simple diagrams over a single large, complex one.
 
 # Context
-
-{{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
 

--- a/packages/ai-ide/src/browser/code-reviewer-agent.ts
+++ b/packages/ai-ide/src/browser/code-reviewer-agent.ts
@@ -19,6 +19,7 @@ import { LanguageModelRequirement } from '@theia/ai-core/lib/common';
 import { ILogger, nls } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { codeReviewerSystemPrompt, CODE_REVIEWER_SYSTEM_PROMPT_ID } from './code-reviewer-prompt-template';
+import { CONTEXT_FILES_HINT_FRAGMENT_ID } from '../common/turn-prompt-fragment-ids';
 
 export const CodeReviewerAgentId = 'code-reviewer';
 
@@ -40,5 +41,6 @@ export class CodeReviewerAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [{ id: CODE_REVIEWER_SYSTEM_PROMPT_ID, defaultVariant: codeReviewerSystemPrompt, variants: [] }];
     protected override systemPromptId: string = CODE_REVIEWER_SYSTEM_PROMPT_ID;
+    protected override turnPromptId: string | undefined = CONTEXT_FILES_HINT_FRAGMENT_ID;
     override iconClass: string = 'codicon codicon-code-review';
 }

--- a/packages/ai-ide/src/browser/code-reviewer-prompt-template.ts
+++ b/packages/ai-ide/src/browser/code-reviewer-prompt-template.ts
@@ -125,8 +125,6 @@ You receive:
 
 # Context
 
-{{contextFiles}}
-
 {{prompt:project-info}}
 `
 };

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -34,6 +34,7 @@ import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { AI_CHAT_HOME, ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
 import { AgentModeConfirmationService } from './agent-mode-confirmation-service';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
 
 export const CoderAgentId = 'Coder';
 
@@ -80,6 +81,7 @@ export class CoderAgent extends AbstractModeAwareChatAgent {
         variants: [getCoderPromptTemplateEdit(), getCoderAgentModeNextPromptTemplate()]
     }];
     protected override systemPromptId: string | undefined = CODER_SYSTEM_PROMPT_ID;
+    protected override turnPromptId: string | undefined = OPEN_EDITORS_HINT_FRAGMENT_ID;
 
     private useSettingsDefaultMode = false;
 

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -34,7 +34,7 @@ import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { AI_CHAT_HOME, ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
 import { AgentModeConfirmationService } from './agent-mode-confirmation-service';
-import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
+import { CODER_TURN_PROMPT_ID } from '../common/turn-prompt-fragment-ids';
 
 export const CoderAgentId = 'Coder';
 
@@ -81,7 +81,7 @@ export class CoderAgent extends AbstractModeAwareChatAgent {
         variants: [getCoderPromptTemplateEdit(), getCoderAgentModeNextPromptTemplate()]
     }];
     protected override systemPromptId: string | undefined = CODER_SYSTEM_PROMPT_ID;
-    protected override turnPromptId: string | undefined = OPEN_EDITORS_HINT_FRAGMENT_ID;
+    protected override turnPromptId: string | undefined = CODER_TURN_PROMPT_ID;
 
     private useSettingsDefaultMode = false;
 

--- a/packages/ai-ide/src/browser/create-skill-agent.ts
+++ b/packages/ai-ide/src/browser/create-skill-agent.ts
@@ -22,6 +22,7 @@ import {
     CREATE_SKILL_SYSTEM_DEFAULT_TEMPLATE_ID,
     CREATE_SKILL_SYSTEM_AGENT_MODE_TEMPLATE_ID,
 } from '../common/create-skill-prompt-template';
+import { CONTEXT_FILES_HINT_FRAGMENT_ID } from '../common/turn-prompt-fragment-ids';
 import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
 import { ILogger, nls } from '@theia/core';
 
@@ -60,5 +61,6 @@ export class CreateSkillAgent extends AbstractModeAwareChatAgent {
 
     override prompts = [createSkillSystemVariants];
     protected override systemPromptId: string | undefined = CREATE_SKILL_SYSTEM_PROMPT_TEMPLATE_ID;
+    protected override turnPromptId: string | undefined = CONTEXT_FILES_HINT_FRAGMENT_ID;
 
 }

--- a/packages/ai-ide/src/browser/explore-agent.ts
+++ b/packages/ai-ide/src/browser/explore-agent.ts
@@ -19,6 +19,7 @@ import { LanguageModelRequirement } from '@theia/ai-core/lib/common';
 import { ILogger, nls } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { exploreSystemPrompt, EXPLORE_SYSTEM_PROMPT_ID } from './explore-prompt-template';
+import { CONTEXT_FILES_HINT_FRAGMENT_ID } from '../common/turn-prompt-fragment-ids';
 import { ExploreAgentId } from '../common/agent-ids';
 
 export { ExploreAgentId };
@@ -41,5 +42,6 @@ export class ExploreAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [{ id: EXPLORE_SYSTEM_PROMPT_ID, defaultVariant: exploreSystemPrompt, variants: [] }];
     protected override systemPromptId: string = EXPLORE_SYSTEM_PROMPT_ID;
+    protected override turnPromptId: string | undefined = CONTEXT_FILES_HINT_FRAGMENT_ID;
     override iconClass: string = 'codicon codicon-compass';
 }

--- a/packages/ai-ide/src/browser/explore-prompt-template.ts
+++ b/packages/ai-ide/src/browser/explore-prompt-template.ts
@@ -114,8 +114,6 @@ For each file, include ONLY what is needed for the task:
 
 # Context
 
-{{contextFiles}}
-
 {{prompt:project-info}}
 `
 };

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -137,6 +137,7 @@ import { GitHubCapabilityContribution } from './github-capability-contribution';
 import { ShellExecutionCapabilityContribution } from './shell-execution-capability-contribution';
 import { MemoryCapabilityContribution } from './memory-capability-contribution';
 import { OpenEditorsHintContribution } from './open-editors-hint-contribution';
+import { TurnPromptContribution } from './turn-prompt-contribution';
 import { AgentModeConfirmationService, AgentModeConfirmationServiceImpl } from './agent-mode-confirmation-service';
 import { ExploreAgent } from './explore-agent';
 import { CodeReviewerAgent } from './code-reviewer-agent';
@@ -370,6 +371,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(FrontendApplicationContribution).to(ShellExecutionCapabilityContribution);
     bind(FrontendApplicationContribution).to(MemoryCapabilityContribution);
     bind(FrontendApplicationContribution).to(OpenEditorsHintContribution);
+    bind(FrontendApplicationContribution).to(TurnPromptContribution);
 
     bind(FrontendApplicationContribution).to(CodeReviewCapabilityContribution);
     bind(FrontendApplicationContribution).to(PRReviewCapabilityContribution);

--- a/packages/ai-ide/src/browser/open-editors-hint-contribution.spec.ts
+++ b/packages/ai-ide/src/browser/open-editors-hint-contribution.spec.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+import { expect } from 'chai';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
+import { getCoderAgentModePromptTemplate, getCoderAgentModeNextPromptTemplate, getCoderPromptTemplateEdit } from '../common/coder-replace-prompt-template';
+import { universalTemplate, universalTemplateVariant } from '../common/universal-prompt-template';
+import { UniversalChatAgent } from '../common/universal-chat-agent';
+import { architectSystemVariants } from './architect-prompt-template';
+import { OPEN_EDITORS_HINT_TEMPLATE } from './open-editors-hint-contribution';
+import { CoderAgent } from './coder-agent';
+import { ArchitectAgent } from './architect-agent';
+
+// Constructed here, while jsdom is still enabled: their field initializers read
+// FrontendApplicationConfigProvider.get(), which needs `window`. Their init() is @postConstruct
+// and is not run outside of DI, so this is safe without a full container.
+const agentsWithOpenEditorsHintTurnPrompt = [new CoderAgent(), new ArchitectAgent(), new UniversalChatAgent()];
+
+disableJSDOM();
+
+describe('open-editors-hint', () => {
+    const include = `{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}`;
+    const systemTemplates = [
+        getCoderAgentModePromptTemplate(), getCoderAgentModeNextPromptTemplate(), getCoderPromptTemplateEdit(),
+        architectSystemVariants.defaultVariant, ...(architectSystemVariants.variants ?? []),
+        universalTemplate, universalTemplateVariant
+    ];
+
+    it('is no longer included in any shipped system prompt (it is sent per turn instead)', () => {
+        for (const template of systemTemplates) {
+            expect(template.template, template.id).not.to.contain(include);
+            expect(template.template, template.id).not.to.contain('{{openEditors}}');
+        }
+    });
+
+    it('describes the list as current as of the message and references the openEditors variable', () => {
+        expect(OPEN_EDITORS_HINT_TEMPLATE).to.contain('as of this message');
+        expect(OPEN_EDITORS_HINT_TEMPLATE).to.contain('{{openEditors}}');
+    });
+
+    it('is declared as the turn prompt of Coder, Architect and Universal, so it is sent per turn instead', () => {
+        for (const agent of agentsWithOpenEditorsHintTurnPrompt) {
+            expect((agent as unknown as { turnPromptId?: string }).turnPromptId, agent.id).to.equal(OPEN_EDITORS_HINT_FRAGMENT_ID);
+        }
+    });
+});

--- a/packages/ai-ide/src/browser/open-editors-hint-contribution.spec.ts
+++ b/packages/ai-ide/src/browser/open-editors-hint-contribution.spec.ts
@@ -25,13 +25,17 @@ import { universalTemplate, universalTemplateVariant } from '../common/universal
 import { UniversalChatAgent } from '../common/universal-chat-agent';
 import { architectSystemVariants } from './architect-prompt-template';
 import { OPEN_EDITORS_HINT_TEMPLATE } from './open-editors-hint-contribution';
+import { ARCHITECT_TURN_PROMPT_TEMPLATE, CODER_TURN_PROMPT_TEMPLATE } from './turn-prompt-contribution';
+import { ARCHITECT_TURN_PROMPT_ID, CODER_TURN_PROMPT_ID } from '../common/turn-prompt-fragment-ids';
 import { CoderAgent } from './coder-agent';
 import { ArchitectAgent } from './architect-agent';
 
 // Constructed here, while jsdom is still enabled: their field initializers read
 // FrontendApplicationConfigProvider.get(), which needs `window`. Their init() is @postConstruct
 // and is not run outside of DI, so this is safe without a full container.
-const agentsWithOpenEditorsHintTurnPrompt = [new CoderAgent(), new ArchitectAgent(), new UniversalChatAgent()];
+const coder = new CoderAgent();
+const architect = new ArchitectAgent();
+const universal = new UniversalChatAgent();
 
 disableJSDOM();
 
@@ -55,9 +59,12 @@ describe('open-editors-hint', () => {
         expect(OPEN_EDITORS_HINT_TEMPLATE).to.contain('{{openEditors}}');
     });
 
-    it('is declared as the turn prompt of Coder, Architect and Universal, so it is sent per turn instead', () => {
-        for (const agent of agentsWithOpenEditorsHintTurnPrompt) {
-            expect((agent as unknown as { turnPromptId?: string }).turnPromptId, agent.id).to.equal(OPEN_EDITORS_HINT_FRAGMENT_ID);
-        }
+    it('is sent per turn: Universal declares it as its turn prompt, Coder and Architect include it in theirs', () => {
+        const turnPromptIdOf = (agent: object): string | undefined => (agent as { turnPromptId?: string }).turnPromptId;
+        expect(turnPromptIdOf(universal)).to.equal(OPEN_EDITORS_HINT_FRAGMENT_ID);
+        expect(turnPromptIdOf(coder)).to.equal(CODER_TURN_PROMPT_ID);
+        expect(CODER_TURN_PROMPT_TEMPLATE).to.contain(include);
+        expect(turnPromptIdOf(architect)).to.equal(ARCHITECT_TURN_PROMPT_ID);
+        expect(ARCHITECT_TURN_PROMPT_TEMPLATE).to.contain(include);
     });
 });

--- a/packages/ai-ide/src/browser/open-editors-hint-contribution.ts
+++ b/packages/ai-ide/src/browser/open-editors-hint-contribution.ts
@@ -19,6 +19,16 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { PromptService } from '@theia/ai-core/lib/common';
 import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
 
+/**
+ * Per-turn hint listing the currently open editors. Agents send it inside the user turn (see
+ * `AbstractChatAgent.turnPromptId`), not in the system prompt, so the system prompt stays cacheable.
+ */
+export const OPEN_EDITORS_HINT_TEMPLATE = `## Open Editors
+The following files are open in the user's editor as of this message. This is contextual information only \
+— they may or may not be relevant to the request. Do not assume they are related unless the user refers to them.
+
+{{openEditors}}`;
+
 @injectable()
 export class OpenEditorsHintContribution implements FrontendApplicationContribution {
 
@@ -26,13 +36,6 @@ export class OpenEditorsHintContribution implements FrontendApplicationContribut
     protected readonly promptService: PromptService;
 
     onStart(): void {
-        this.promptService.addBuiltInPromptFragment({
-            id: OPEN_EDITORS_HINT_FRAGMENT_ID,
-            template: `## Open Editors
-The following files are currently open in the user's editor. This is provided as contextual information only \
-— these files may or may not be relevant to the current request. Do not assume they are related unless the user explicitly refers to them.
-
-{{openEditors}}`
-        });
+        this.promptService.addBuiltInPromptFragment({ id: OPEN_EDITORS_HINT_FRAGMENT_ID, template: OPEN_EDITORS_HINT_TEMPLATE });
     }
 }

--- a/packages/ai-ide/src/browser/project-info-agent.ts
+++ b/packages/ai-ide/src/browser/project-info-agent.ts
@@ -17,6 +17,7 @@ import { AbstractStreamParsingChatAgent } from '@theia/ai-chat';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { projectInfoSystemVariants, projectInfoTemplateVariants } from '../common/project-info-prompt-template';
+import { CONTEXT_FILES_HINT_FRAGMENT_ID } from '../common/turn-prompt-fragment-ids';
 import { ILogger, nls } from '@theia/core';
 
 @injectable()
@@ -39,5 +40,6 @@ export class ProjectInfoAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [projectInfoSystemVariants, projectInfoTemplateVariants];
     protected override systemPromptId: string | undefined = projectInfoSystemVariants.id;
+    protected override turnPromptId: string | undefined = CONTEXT_FILES_HINT_FRAGMENT_ID;
     override iconClass: string = 'codicon codicon-repo';
 }

--- a/packages/ai-ide/src/browser/review/pr-review-agent.ts
+++ b/packages/ai-ide/src/browser/review/pr-review-agent.ts
@@ -19,6 +19,7 @@ import { LanguageModelRequirement } from '@theia/ai-core/lib/common';
 import { ILogger, nls } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { PR_REVIEW_SYSTEM_PROMPT_ID, prReviewSystemPrompt } from './pr-review-prompt-template';
+import { CONTEXT_FILES_HINT_FRAGMENT_ID } from '../../common/turn-prompt-fragment-ids';
 
 export const PRReviewAgentId = 'pr-reviewer';
 
@@ -41,5 +42,6 @@ export class PRReviewAgent extends AbstractStreamParsingChatAgent {
     override iconClass: string = 'codicon codicon-git-pull-request-go-to-changes';
     override prompts = [{ id: PR_REVIEW_SYSTEM_PROMPT_ID, defaultVariant: prReviewSystemPrompt, variants: [] }];
     protected override systemPromptId: string = PR_REVIEW_SYSTEM_PROMPT_ID;
+    protected override turnPromptId: string | undefined = CONTEXT_FILES_HINT_FRAGMENT_ID;
     override tags: string[] = [...this.tags, 'Alpha'];
 }

--- a/packages/ai-ide/src/browser/review/pr-review-prompt-template.ts
+++ b/packages/ai-ide/src/browser/review/pr-review-prompt-template.ts
@@ -16,7 +16,7 @@
 // *****************************************************************************
 
 import { BasePromptFragment } from '@theia/ai-core/lib/common';
-import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from '../../common/context-variables';
+import { TASK_CONTEXT_SUMMARY_VARIABLE_ID } from '../../common/context-variables';
 import {
     FILE_CONTENT_FUNCTION_ID,
     GET_FILE_DIAGNOSTICS_ID,
@@ -490,8 +490,6 @@ When encountering failures, handle them gracefully instead of stopping:
 Where a Mermaid diagram is genuinely useful, use one, for example to explain architecture considerations or a new flow. Include it as a fenced \`mermaid\` code block in the user-facing walkthrough messages, such as the Overview step. It renders directly in the chat, so keep it small and focused. The walkthrough stays terse and chat space is limited.
 
 # Context
-
-{{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
 

--- a/packages/ai-ide/src/browser/turn-prompt-contribution.spec.ts
+++ b/packages/ai-ide/src/browser/turn-prompt-contribution.spec.ts
@@ -1,0 +1,99 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+import { expect } from 'chai';
+import { BasePromptFragment } from '@theia/ai-core';
+import { CHANGE_SET_SUMMARY_VARIABLE } from '@theia/ai-chat/lib/browser/change-set-variable';
+import { CONTEXT_FILES_VARIABLE } from '../common/context-files-variable';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
+import { ARCHITECT_TURN_PROMPT_ID, CODER_TURN_PROMPT_ID, CONTEXT_FILES_HINT_FRAGMENT_ID } from '../common/turn-prompt-fragment-ids';
+import { getCoderAgentModePromptTemplate, getCoderAgentModeNextPromptTemplate, getCoderPromptTemplateEdit } from '../common/coder-replace-prompt-template';
+import { universalTemplate, universalTemplateVariant } from '../common/universal-prompt-template';
+import { projectInfoSystemVariants } from '../common/project-info-prompt-template';
+import { createSkillSystemVariants } from '../common/create-skill-prompt-template';
+import { architectSystemVariants } from './architect-prompt-template';
+import { codeReviewerSystemPrompt } from './code-reviewer-prompt-template';
+import { exploreSystemPrompt } from './explore-prompt-template';
+import { prReviewSystemPrompt } from './review/pr-review-prompt-template';
+import { ARCHITECT_TURN_PROMPT_TEMPLATE, CODER_TURN_PROMPT_TEMPLATE, CONTEXT_FILES_HINT_TEMPLATE } from './turn-prompt-contribution';
+import { CoderAgent } from './coder-agent';
+import { ArchitectAgent } from './architect-agent';
+import { CodeReviewerAgent } from './code-reviewer-agent';
+import { ExploreAgent } from './explore-agent';
+import { PRReviewAgent } from './review/pr-review-agent';
+import { ProjectInfoAgent } from './project-info-agent';
+import { CreateSkillAgent } from './create-skill-agent';
+
+// Constructed while jsdom is still enabled: field initializers may read FrontendApplicationConfigProvider.get(),
+// which needs `window`. Their init() is @postConstruct and is not run outside of DI.
+const agentsWithContextFilesTurnPrompt = [new CodeReviewerAgent(), new ExploreAgent(), new PRReviewAgent(), new ProjectInfoAgent(), new CreateSkillAgent()];
+const coder = new CoderAgent();
+const architect = new ArchitectAgent();
+
+disableJSDOM();
+
+describe('turn prompts for chat context', () => {
+    const turnPromptIdOf = (agent: object): string | undefined => (agent as { turnPromptId?: string }).turnPromptId;
+    const variantsOf = (set: { defaultVariant: BasePromptFragment, variants?: BasePromptFragment[] }): BasePromptFragment[] => [set.defaultVariant, ...(set.variants ?? [])];
+    const systemTemplates: BasePromptFragment[] = [
+        getCoderAgentModePromptTemplate(), getCoderAgentModeNextPromptTemplate(), getCoderPromptTemplateEdit(),
+        ...variantsOf(architectSystemVariants),
+        universalTemplate, universalTemplateVariant,
+        codeReviewerSystemPrompt, exploreSystemPrompt, prReviewSystemPrompt,
+        ...variantsOf(projectInfoSystemVariants), ...variantsOf(createSkillSystemVariants)
+    ];
+
+    it('no shipped system prompt embeds the attached files or the change set summary any more (they are sent per turn)', () => {
+        for (const template of systemTemplates) {
+            expect(template.template, template.id).not.to.contain('{{contextFiles}}');
+            expect(template.template, template.id).not.to.contain('{{changeSetSummary}}');
+        }
+    });
+
+    it('the attached-files hint is current as of the message and lists the contextFiles variable', () => {
+        expect(CONTEXT_FILES_HINT_TEMPLATE).to.contain('as of this message');
+        expect(CONTEXT_FILES_HINT_TEMPLATE).to.contain('{{contextFiles}}');
+    });
+
+    it('Coder sends open editors, attached files and the change set summary per turn', () => {
+        expect(turnPromptIdOf(coder)).to.equal(CODER_TURN_PROMPT_ID);
+        expect(CODER_TURN_PROMPT_TEMPLATE).to.contain(`{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}`);
+        expect(CODER_TURN_PROMPT_TEMPLATE).to.contain(`{{prompt:${CONTEXT_FILES_HINT_FRAGMENT_ID}}}`);
+        expect(CODER_TURN_PROMPT_TEMPLATE).to.contain('{{changeSetSummary}}');
+    });
+
+    it('Architect sends open editors and attached files per turn', () => {
+        expect(turnPromptIdOf(architect)).to.equal(ARCHITECT_TURN_PROMPT_ID);
+        expect(ARCHITECT_TURN_PROMPT_TEMPLATE).to.contain(`{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}`);
+        expect(ARCHITECT_TURN_PROMPT_TEMPLATE).to.contain(`{{prompt:${CONTEXT_FILES_HINT_FRAGMENT_ID}}}`);
+        expect(ARCHITECT_TURN_PROMPT_TEMPLATE).not.to.contain('{{changeSetSummary}}');
+    });
+
+    it('Code Reviewer, Explore, PR Review, Project Info and Create Skill send the attached files per turn', () => {
+        for (const agent of agentsWithContextFilesTurnPrompt) {
+            expect(turnPromptIdOf(agent), agent.id).to.equal(CONTEXT_FILES_HINT_FRAGMENT_ID);
+        }
+    });
+
+    it('the attached files and the change set summary count as volatile, so a system prompt that still embeds them is warned about', () => {
+        expect(CONTEXT_FILES_VARIABLE.isVolatile).to.be.true;
+        expect(CHANGE_SET_SUMMARY_VARIABLE.isVolatile).to.be.true;
+    });
+});

--- a/packages/ai-ide/src/browser/turn-prompt-contribution.ts
+++ b/packages/ai-ide/src/browser/turn-prompt-contribution.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '@theia/ai-core/lib/common';
+import { CHANGE_SET_SUMMARY_VARIABLE_ID } from '@theia/ai-chat';
+import { CONTEXT_FILES_VARIABLE_ID } from '../common/context-variables';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
+import { ARCHITECT_TURN_PROMPT_ID, CODER_TURN_PROMPT_ID, CONTEXT_FILES_HINT_FRAGMENT_ID } from '../common/turn-prompt-fragment-ids';
+
+/**
+ * Per-turn hint listing the files the user attached to the chat. Sent inside the user turn (see
+ * `AbstractChatAgent.turnPromptId`), not in the system prompt: attaching or removing a file would otherwise rewrite
+ * the system prompt and invalidate the prompt cache for the whole conversation.
+ */
+export const CONTEXT_FILES_HINT_TEMPLATE = `## Provided Files
+The following files were provided for additional context as of this message. Some may be referred to by the user \
+(e.g. "this file" or "the attachment"). Read the relevant ones before you act.
+
+{{${CONTEXT_FILES_VARIABLE_ID}}}`;
+
+/**
+ * Coder's turn prompt: the open editors, the attached files and the summary of its change set. The change set
+ * summary renders its own heading and is empty while nothing has been changed.
+ */
+export const CODER_TURN_PROMPT_TEMPLATE = `{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
+
+{{prompt:${CONTEXT_FILES_HINT_FRAGMENT_ID}}}
+
+{{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}`;
+
+/** Architect's turn prompt: the open editors and the attached files. */
+export const ARCHITECT_TURN_PROMPT_TEMPLATE = `{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
+
+{{prompt:${CONTEXT_FILES_HINT_FRAGMENT_ID}}}`;
+
+/** Registers the per-turn prompt fragments that carry chat context which changes between turns. */
+@injectable()
+export class TurnPromptContribution implements FrontendApplicationContribution {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    onStart(): void {
+        this.promptService.addBuiltInPromptFragment({ id: CONTEXT_FILES_HINT_FRAGMENT_ID, template: CONTEXT_FILES_HINT_TEMPLATE });
+        this.promptService.addBuiltInPromptFragment({ id: CODER_TURN_PROMPT_ID, template: CODER_TURN_PROMPT_TEMPLATE });
+        this.promptService.addBuiltInPromptFragment({ id: ARCHITECT_TURN_PROMPT_ID, template: ARCHITECT_TURN_PROMPT_TEMPLATE });
+    }
+}

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -36,7 +36,6 @@ import {
 } from './file-changeset-function-ids';
 import { GET_TASK_CONTEXT_FUNCTION_ID } from './task-context-function-ids';
 import { ArchitectAgentId, ExploreAgentId } from './agent-ids';
-import { OPEN_EDITORS_HINT_FRAGMENT_ID } from './open-editors-hint-fragment-id';
 
 export const CODER_SYSTEM_PROMPT_ID = 'coder-system';
 
@@ -258,8 +257,6 @@ Always retrieve relevant files using ~{${FILE_CONTENT_FUNCTION_ID}} to understan
 
 ## Project Info
 {{prompt:project-info}}
-
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 
@@ -549,8 +546,6 @@ Always retrieve relevant files using ~{${FILE_CONTENT_FUNCTION_ID}} to understan
 ## Project Info
 {{prompt:project-info}}
 
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
-
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 
 # Final Instruction
@@ -640,8 +635,6 @@ You have previously proposed changes for the following files. Some suggestions m
 {{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}
 
 {{prompt:project-info}}
-
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -10,7 +10,6 @@
 // *****************************************************************************
 
 import { AGENT_DELEGATION_FUNCTION_ID, BasePromptFragment } from '@theia/ai-core/lib/common';
-import { CHANGE_SET_SUMMARY_VARIABLE_ID } from '@theia/ai-chat';
 import {
     GET_WORKSPACE_FILE_LIST_FUNCTION_ID,
     FILE_CONTENT_FUNCTION_ID,
@@ -24,7 +23,7 @@ import {
     STOP_LAUNCH_CONFIGURATION_FUNCTION_ID
 } from './workspace-functions';
 import { TODO_WRITE_FUNCTION_ID } from './todo-tool';
-import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
+import { TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
 import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 import {
     SUGGEST_FILE_CONTENT_ID,
@@ -246,14 +245,6 @@ Do NOT ask for confirmation on:
 (a fenced \`mermaid\` code block, rendered in the chat). Chat space is limited, so avoid large or overly complex diagrams.
 
 # Context
-
-## Provided Files
-The following files have been provided for additional context. Some may be referred to by the user (e.g., "this file" or "the attachment"). \
-Always retrieve relevant files using ~{${FILE_CONTENT_FUNCTION_ID}} to understand your task.
-{{${CONTEXT_FILES_VARIABLE_ID}}}
-
-## Previously Changed Files
-{{changeSetSummary}}
 
 ## Project Info
 {{prompt:project-info}}
@@ -535,14 +526,6 @@ Search for files only when a change is requested.
 
 # Context
 
-## Provided Files
-The following files have been provided for additional context. Some may be referred to by the user (e.g., "this file" or "the attachment").
-Always retrieve relevant files using ~{${FILE_CONTENT_FUNCTION_ID}} to understand your task.
-{{${CONTEXT_FILES_VARIABLE_ID}}}
-
-## Previously Changed Files
-{{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}
-
 ## Project Info
 {{prompt:project-info}}
 
@@ -623,16 +606,6 @@ Be aware this function operates on the workspace. If the user has not accepted a
 
 When a diagram clarifies an architectural concept or how something is implemented, include a Mermaid diagram (a fenced \`mermaid\` code block) in your response. \
 It is rendered directly in the chat. Keep diagrams small and focused. The chat has limited space, so prefer a few simple diagrams over a single large, complex one.
-
-## Additional Context
-
-The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). \
-Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
-{{${CONTEXT_FILES_VARIABLE_ID}}}
-
-## Previously Proposed Changes
-You have previously proposed changes for the following files. Some suggestions may have been accepted by the user, while others may still be pending.
-{{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}
 
 {{prompt:project-info}}
 

--- a/packages/ai-ide/src/common/context-files-variable.spec.ts
+++ b/packages/ai-ide/src/common/context-files-variable.spec.ts
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { AIVariableResolutionRequest } from '@theia/ai-core';
+import { CONTEXT_FILES_VARIABLE, ContextFilesVariableContribution, NO_CONTEXT_FILES_VALUE } from './context-files-variable';
+
+describe('ContextFilesVariableContribution', () => {
+
+    /** A chat session context whose session carries the given context variables. */
+    function sessionContext(variables: AIVariableResolutionRequest[]): object {
+        return { model: { context: { getVariables: () => variables } } };
+    }
+
+    const file = (path: string): AIVariableResolutionRequest => ({ variable: { id: 'file', name: 'file', description: '' }, arg: path });
+
+    it('lists the attached files, one per line', async () => {
+        const context = sessionContext([file('src/a.ts'), { variable: { id: 'other', name: 'other', description: '' }, arg: 'x' }, file('src/b.ts')]);
+        const result = await new ContextFilesVariableContribution().resolve({ variable: CONTEXT_FILES_VARIABLE }, context);
+        expect(result?.value).to.equal('- src/a.ts\n- src/b.ts');
+    });
+
+    it('resolves to an explicit marker when no file is attached', async () => {
+        const result = await new ContextFilesVariableContribution().resolve({ variable: CONTEXT_FILES_VARIABLE }, sessionContext([]));
+        expect(result?.value).to.equal(NO_CONTEXT_FILES_VALUE);
+    });
+
+    it('resolves nothing outside of a chat session context', async () => {
+        const result = await new ContextFilesVariableContribution().resolve({ variable: CONTEXT_FILES_VARIABLE }, {});
+        expect(result).to.be.undefined;
+    });
+});

--- a/packages/ai-ide/src/common/context-files-variable.ts
+++ b/packages/ai-ide/src/common/context-files-variable.ts
@@ -24,6 +24,7 @@ export const CONTEXT_FILES_VARIABLE: AIVariable = {
     id: CONTEXT_FILES_VARIABLE_ID,
     description: nls.localize('theia/ai/core/contextSummaryVariable/description', 'Describes files in the context for a given session.'),
     name: CONTEXT_FILES_VARIABLE_ID,
+    isVolatile: true
 };
 
 /** Value of {@link CONTEXT_FILES_VARIABLE} when no file is attached, so prompts render an explicit marker instead of an empty list. */

--- a/packages/ai-ide/src/common/context-files-variable.ts
+++ b/packages/ai-ide/src/common/context-files-variable.ts
@@ -26,6 +26,9 @@ export const CONTEXT_FILES_VARIABLE: AIVariable = {
     name: CONTEXT_FILES_VARIABLE_ID,
 };
 
+/** Value of {@link CONTEXT_FILES_VARIABLE} when no file is attached, so prompts render an explicit marker instead of an empty list. */
+export const NO_CONTEXT_FILES_VALUE = 'none';
+
 @injectable()
 export class ContextFilesVariableContribution implements AIVariableContribution, AIVariableResolver {
     registerVariables(service: AIVariableService): void {
@@ -40,10 +43,11 @@ export class ContextFilesVariableContribution implements AIVariableContribution,
         if (!ChatSessionContext.is(context) || request.variable.name !== CONTEXT_FILES_VARIABLE.name) { return undefined; }
         const variables = ChatSessionContext.getVariables(context);
 
+        const files = variables.filter(variable => variable.variable.name === 'file' && !!variable.arg)
+            .map(variable => `- ${variable.arg}`);
         return {
             variable: CONTEXT_FILES_VARIABLE,
-            value: variables.filter(variable => variable.variable.name === 'file' && !!variable.arg)
-                .map(variable => `- ${variable.arg}`).join('\n')
+            value: files.length > 0 ? files.join('\n') : NO_CONTEXT_FILES_VALUE
         };
     }
 }

--- a/packages/ai-ide/src/common/create-skill-prompt-template.ts
+++ b/packages/ai-ide/src/common/create-skill-prompt-template.ts
@@ -18,7 +18,6 @@ import {
     GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID,
     FIND_FILES_BY_PATTERN_FUNCTION_ID
 } from './workspace-functions';
-import { CONTEXT_FILES_VARIABLE_ID } from './context-variables';
 import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 import {
     SUGGEST_FILE_CONTENT_ID,
@@ -147,10 +146,6 @@ This skill provides instructions for performing comprehensive code reviews.
 - Prioritize issues by severity
 - Suggest improvements, not just point out problems
 \`\`\`
-
-## Additional Context
-
-{{${CONTEXT_FILES_VARIABLE_ID}}}
 
 ## Non-Negotiable Requirements
 - Skill names MUST be lowercase kebab-case. Always. No exceptions.

--- a/packages/ai-ide/src/common/project-info-prompt-template.ts
+++ b/packages/ai-ide/src/common/project-info-prompt-template.ts
@@ -13,7 +13,6 @@ import {
     GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID,
     FIND_FILES_BY_PATTERN_FUNCTION_ID
 } from './workspace-functions';
-import { CONTEXT_FILES_VARIABLE_ID } from './context-variables';
 import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 import {
     SUGGEST_FILE_CONTENT_ID,
@@ -147,10 +146,6 @@ Use these functions liberally to suggest file changes. All changes require user 
 - **~{${CLEAR_FILE_CHANGES_ID}}**: Clear all pending changes for a file to start fresh
 
 {{prompt:${PROJECT_INFO_TEMPLATE_PROMPT_ID}}}
-
-## Additional Context
-
-{{${CONTEXT_FILES_VARIABLE_ID}}}
 
 ## Workflow Guidelines
 

--- a/packages/ai-ide/src/common/turn-prompt-fragment-ids.ts
+++ b/packages/ai-ide/src/common/turn-prompt-fragment-ids.ts
@@ -1,0 +1,25 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Id of the per-turn fragment listing the files the user attached to the chat. Agents send it inside the user turn
+ * (see `AbstractChatAgent.turnPromptId`) so that attaching or removing a file does not rewrite the system prompt.
+ */
+export const CONTEXT_FILES_HINT_FRAGMENT_ID = 'context-files-hint';
+/** Id of Coder's turn prompt: open editors, attached files and the change set summary. */
+export const CODER_TURN_PROMPT_ID = 'coder-turn-prompt';
+/** Id of Architect's turn prompt: open editors and attached files. */
+export const ARCHITECT_TURN_PROMPT_ID = 'architect-turn-prompt';

--- a/packages/ai-ide/src/common/universal-chat-agent.ts
+++ b/packages/ai-ide/src/common/universal-chat-agent.ts
@@ -19,6 +19,7 @@ import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { AbstractStreamParsingChatAgent } from '@theia/ai-chat/lib/common/chat-agents';
 import { ILogger, nls } from '@theia/core';
 import { universalTemplate, universalTemplateVariant } from './universal-prompt-template';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from './open-editors-hint-fragment-id';
 
 export const UniversalChatAgentId = 'Universal';
 @injectable()
@@ -35,10 +36,10 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent {
    protected defaultLanguageModelPurpose: string = 'chat';
    override description = nls.localize('theia/ai/chat/universal/description', 'This agent is designed to help software developers by providing concise and accurate '
       + 'answers to general programming and software development questions. It is also the fall-back for any generic '
-      + 'questions the user might ask. The universal agent currently does not have any context by default, i.e. it cannot '
-      + 'access the current user context or the workspace.');
+      + 'questions the user might ask. It is aware of the files currently open in the editor but has no workspace access.');
 
    override prompts = [{ id: 'universal-system', defaultVariant: universalTemplate, variants: [universalTemplateVariant] }];
    protected override systemPromptId: string = 'universal-system';
+   protected override turnPromptId: string | undefined = OPEN_EDITORS_HINT_FRAGMENT_ID;
    override iconClass: string = 'codicon codicon-comment';
 }

--- a/packages/ai-ide/src/common/universal-prompt-template.ts
+++ b/packages/ai-ide/src/common/universal-prompt-template.ts
@@ -11,7 +11,6 @@
 
 import { BasePromptFragment } from '@theia/ai-core/lib/common';
 import { CHAT_CONTEXT_DETAILS_VARIABLE_ID } from '@theia/ai-chat';
-import { OPEN_EDITORS_HINT_FRAGMENT_ID } from './open-editors-hint-fragment-id';
 
 export const universalTemplate: BasePromptFragment = {
    id: 'universal-system-default',
@@ -24,8 +23,6 @@ You are an assistant integrated into {{productName}}, designed to assist softwar
 ## Current Context
 Some files and other pieces of data may have been added by the user to the context of the chat. If any have, the details can be found below.
 {{${CHAT_CONTEXT_DETAILS_VARIABLE_ID}}}
-
-{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 `
 };
 


### PR DESCRIPTION
#### What it does

Fixes #17986.

Editor state (open editors, active editor, selection) was resolved into the system prompt on every request. Prompt caching is prefix-based, so switching tabs or changing the selection between turns invalidated the system and messages cache tiers and re-ingested the whole conversation. Instructions now stay in the system prompt; state travels with the turn and is replayed verbatim, so history is append-only.

- **ai-core:** `AIVariable.isVolatile` marks the editor-state variables (`openEditors`, `_ff`, `selectedText`, `currentRelativeFilePath`, `_f`, `currentAbsoluteFilePath`, `currentFileContent`, `currentRelativeDirPath`, `lineNumber`); `ResolvedAIVariable.findVolatile` collects them. Theia-mapped variables (`currentRelativeFilePath` and friends) resolve to an empty value instead of the literal `${relativeFile}` when there is no active editor, and `openEditors`/`_ff` resolve to `none` when nothing is open.
- **ai-chat:** `AbstractChatAgent.turnPromptId` names a fragment resolved per request. Its text is stored on the request (`ChatRequestModel.turnPrompt`, serialized with the session) and prepended to the user's message in `getMessages`, so every provider sees one user turn and later turns re-send the same bytes. Tool references in the fragment are merged like system-prompt ones. One warning per agent and prompt variant when a system prompt resolves a volatile variable, one per unknown turn prompt id.
- **ai-ide:** the seven `{{prompt:open-editors-hint}}` includes are removed from the Coder, Architect and Universal system templates, and `{{contextFiles}}` / `{{changeSetSummary}}` from every shipped system template that embedded them (Coder, Architect, Code Reviewer, Explore, PR Review, Project Info, Create Skill): attaching a file or an edit turn changed them just like a tab switch. New fragments `context-files-hint`, `coder-turn-prompt` (open editors, attached files, change set summary) and `architect-turn-prompt` (open editors, attached files); Universal sends `open-editors-hint`, the other five agents `context-files-hint`. `contextFiles` and `changeSetSummary` are flagged volatile, and `contextFiles` resolves to `none` when nothing is attached. The `open-editors-hint` id is kept, so existing customizations still work; its text now says "as of this message".
- **Custom agents:** optional `turnPrompt: <fragment id>` in the `agent.md` frontmatter (validated, round-trips through the `customAgents.yml` migration).
- **ai-claude-code:** `systemPrompt.append` is stable; selection, active editor, open editors and context files go into an `<ide-context>` block prepended to the SDK `prompt`, as a new customizable fragment `claude-code-ide-context`. Usage guidance stays in the appendix.

Adopters whose customized templates still include the hint, `{{contextFiles}}` or `{{changeSetSummary}}` get that content twice (system prompt and turn) plus one console warning pointing at the fix.

#### How to test

1. Anthropic model with `useCaching` on, Coder agent: send a request, switch editor tabs, send another. In AI History the two system prompts are byte-identical and each user message starts with `## Open Editors … as of this message` listing the files open at that time, followed by `## Provided Files` and, once Coder has changed something, `## Previously Proposed Changes`; the first block is replayed unchanged in the second request. Token Usage shows the second request read the system prompt and turn-1 history from cache instead of writing it.
2. Custom agent whose `agent.md` body contains `{{openEditors}}`: the console logs one `ai-chat:CustomChatAgent` warning on first use. Add `turnPrompt: open-editors-hint` to its frontmatter: the list moves into the user turn and the warning goes away.
3. Claude Code agent: the CLI request carries the stable appendix in `systemPrompt.append` and the `<ide-context>` block at the start of the user prompt (visible in AI History).
4. Unit tests: `chat-agents.spec.ts` (replay, tool merge inputs, warnings), `chat-model.spec.ts` (serialization), `variable-service.spec.ts`, `prompt-service.spec.ts` and `frontend-prompt-customization-service.spec.ts` (frontmatter), `open-editors-hint-contribution.spec.ts` and `turn-prompt-contribution.spec.ts` (templates, agent wiring, volatile flags), `theia-variable-contribution.spec.ts`, `open-editors-variable-contribution.spec.ts` and `context-files-variable.spec.ts` (empty values), `claude-code-chat-agent.spec.ts`.

#### Follow-ups

- `contextDetails` and `taskContextSummary` stay in system prompts; they change only through deliberate user or agent actions.
- `appendExternalFileChangeNotice` appends a trailing user message that is not persisted, the same class of history edit; separate fix.
- The block is always sent; emitting it only when the state changed can be added without an API change.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

