### PR TITLE
fix(ai-registry): resolve MCP entries via any approval with a usable install config

### DIFF
--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
@@ -129,6 +129,126 @@ describe('MCPRegistryEntryResolver.resolve', () => {
         expect(resolved?.config).to.deep.equal({ command: 'new-cmd' });
     });
 
+    it('falls back to an older approval when the most recent one has no usable install config', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/example-mcp',
+            name: 'Example',
+            description: 'Example MCP server',
+            mcpRegistryVerified: true,
+            approvals: [
+                {
+                    organizationId: 'older-org',
+                    date: '2025-01-01',
+                    version: '^0.5.0',
+                    installConfigs: [{
+                        tool: 'theia-ide',
+                        config: { servers: { example: { command: 'old-cmd' } } }
+                    }]
+                },
+                {
+                    organizationId: 'newer-org',
+                    date: '2026-04-01',
+                    version: '^1.0.0',
+                    installConfigs: []
+                }
+            ]
+        };
+
+        const resolved = resolver.resolve(raw);
+        expect(resolved?.version).to.equal('^0.5.0');
+        expect(resolved?.config).to.deep.equal({ command: 'old-cmd' });
+    });
+
+    it('resolves via the approval that has an install config when approvals share the same date', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'com.eclipsesource/review-guard',
+            name: 'Review Guard',
+            description: 'Self-published with no config, approved via trust with one',
+            mcpRegistryVerified: true,
+            approvals: [
+                {
+                    organizationId: 'eclipsesource',
+                    date: '2026-04-01',
+                    version: '^1.0.0',
+                    installConfigs: []
+                },
+                {
+                    organizationId: 'theia',
+                    date: '2026-04-01',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1',
+                    installConfigs: [{
+                        tool: 'theia-ide',
+                        config: { servers: { 'review-guard': { command: 'npx', args: ['-y', 'review-guard'] } } }
+                    }]
+                }
+            ]
+        };
+
+        const resolved = resolver.resolve(raw);
+        expect(resolved?.localName).to.equal('review-guard');
+        expect(resolved?.config).to.deep.equal({ command: 'npx', args: ['-y', 'review-guard'] });
+        expect(resolved?.configHash).to.equal('hash-v1');
+    });
+
+    it('breaks a date tie between two usable approvals by organizationId, independent of array order', () => {
+        const approvals = [
+            {
+                organizationId: 'theia',
+                date: '2026-04-01',
+                installConfigs: [{ tool: 'theia-ide', config: { servers: { example: { command: 'theia-cmd' } } } }]
+            },
+            {
+                organizationId: 'eclipsesource',
+                date: '2026-04-01',
+                installConfigs: [{ tool: 'theia-ide', config: { servers: { example: { command: 'eclipsesource-cmd' } } } }]
+            }
+        ];
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/tied',
+            name: 'Tied',
+            description: 'Two usable approvals with the same date',
+            mcpRegistryVerified: true,
+            approvals
+        };
+
+        expect(resolver.resolve(raw)?.config).to.deep.equal({ command: 'eclipsesource-cmd' });
+        expect(resolver.resolve({ ...raw, approvals: [...approvals].reverse() })?.config).to.deep.equal({ command: 'eclipsesource-cmd' });
+    });
+
+    it('skips install configs without servers in favour of a usable one within the same approval', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/partial',
+            name: 'Partial',
+            description: 'Approval mixing an empty and a usable install config',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                installConfigs: [
+                    { tool: 'theia-ide', config: { servers: {} } },
+                    { tool: 'theia-ide', config: { servers: { example: { command: 'usable-cmd' } } } }
+                ]
+            }]
+        };
+
+        expect(resolver.resolve(raw)?.config).to.deep.equal({ command: 'usable-cmd' });
+    });
+
+    it('returns undefined when no approval has a usable install config', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/all-empty',
+            name: 'All Empty',
+            description: 'No approval carries an install config',
+            mcpRegistryVerified: true,
+            approvals: [
+                { organizationId: 'first-org', date: '2026-04-01', installConfigs: [] },
+                { organizationId: 'second-org', date: '2026-04-01', installConfigs: [{ tool: 'theia-ide' }] }
+            ]
+        };
+        expect(resolver.resolve(raw)).to.be.undefined;
+    });
+
     it('returns undefined when the server has no approvals', () => {
         const raw: RegistryMCPServer = {
             serverId: 'io.github.example/orphan',
@@ -140,7 +260,7 @@ describe('MCPRegistryEntryResolver.resolve', () => {
         expect(resolver.resolve(raw)).to.be.undefined;
     });
 
-    it('returns undefined when the picked approval has no usable install config', () => {
+    it('returns undefined when the only approval has no usable install config', () => {
         const raw: RegistryMCPServer = {
             serverId: 'io.github.example/empty',
             name: 'Empty',

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { AIRegistryConfiguration } from '../ai-registry-configuration';
-import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp-registry-types';
+import { RegistryApproval, RegistryInstallConfig, RegistryMCPServer, ResolvedRegistryEntry } from './mcp-registry-types';
 import { ILogger } from '@theia/core';
 
 export const MCPRegistryEntryResolver = Symbol('MCPRegistryEntryResolver');
@@ -35,18 +35,18 @@ export class MCPRegistryEntryResolverImpl implements MCPRegistryEntryResolver {
     protected readonly logger: ILogger;
 
     resolve(raw: RegistryMCPServer): ResolvedRegistryEntry | undefined {
-        const approval = [...raw.approvals].sort((a, b) => b.date.localeCompare(a.date))[0];
-        if (!approval) {
+        // Only approvals that actually carry a usable install config are candidates: picking by
+        // date first would drop the entry whenever the winning approval has an empty
+        // `installConfigs` while another - often a trust-derived one, which copies its date - has one.
+        const candidates = raw.approvals
+            .map(candidateApproval => ({ approval: candidateApproval, installConfig: this.selectInstallConfig(candidateApproval) }))
+            .filter((entry): entry is { approval: RegistryApproval, installConfig: RegistryInstallConfig } => entry.installConfig !== undefined);
+        const candidate = this.sortCandidates(candidates)[0];
+        if (!candidate) {
             return undefined;
         }
-        // Per-tool endpoints should already pre-filter install configs, but a registry
-        // may still emit several. Pick the one tagged for our configured tool name
-        // (or untagged, which we treat as "applies to all tools"); fall back to the
-        // first config so a registry that hasn't tagged its entries still works.
-        const toolName = this.configuration.getToolName();
-        const installConfig = approval.installConfigs.find(c => !c.tool || c.tool === toolName || toolName === 'all')
-            ?? approval.installConfigs[0];
-        const servers = installConfig?.config?.servers ?? {};
+        const { approval, installConfig } = candidate;
+        const servers = installConfig.config?.servers ?? {};
         const serverKeys = Object.keys(servers);
         if (serverKeys.length === 0) {
             return undefined;
@@ -68,5 +68,22 @@ export class MCPRegistryEntryResolverImpl implements MCPRegistryEntryResolver {
             ...(approval.configHash !== undefined && { configHash: approval.configHash }),
             mcpRegistryVerified: raw.mcpRegistryVerified
         };
+    }
+
+    /**
+     * The install config of `approval` to use, or `undefined` when it has none with any server.
+     * Prefers the config tagged for our configured tool name (untagged applies to all tools),
+     * falling back to any other usable one so an untagged registry still works.
+     */
+    protected selectInstallConfig(approval: RegistryApproval): RegistryInstallConfig | undefined {
+        const toolName = this.configuration.getToolName();
+        const usable = approval.installConfigs.filter(c => Object.keys(c.config?.servers ?? {}).length > 0);
+        return usable.find(c => !c.tool || c.tool === toolName || toolName === 'all') ?? usable[0];
+    }
+
+    /** Most recent first, `organizationId` ascending on ties, so the pick is a total order. */
+    protected sortCandidates<T extends { approval: RegistryApproval }>(candidates: T[]): T[] {
+        return [...candidates].sort((a, b) =>
+            b.approval.date.localeCompare(a.approval.date) || a.approval.organizationId.localeCompare(b.approval.organizationId));
     }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
`resolve()` picked one approval by date and only looked at its `installConfigs`, so an entry whose newest-dated (or tie-winning) approval has an empty `installConfigs` resolved to `undefined` and was dropped from the Extensions view without any indication. Trust-derived approvals copy the source approval's date, so this tie is common.

Now every approval that actually has a usable install config is a candidate, and the newest of those wins - `organizationId` ascending on ties, so the choice is a total order like the plugin resolver's.

Closes #17994
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. `curl -s https://ai.open-vsx.org/api/v1/all.json | jq '(..|objects|select(.serverId=="com.eclipsesource/review-guard").approvals[0].installConfigs)=[]' > /tmp/reg/all.json` - blanks the first, tie-dated eclipsesource
     approval; the theia one keeps its config.
  2. `npx --yes http-server /tmp/reg -p 8090 --cors` - the app fetches <base>/all.json since getToolName() is 'all'.
  3. Build and start the browser example so the redirected base URL is bundled in.
  4. Search review-guard in Extensions → MCP Servers: listed on this branch, silently absent on master - same with "Only Show Verified Extensions" on and off.
  5. Install it, then check `ai-features.mcp.mcpServers["review-guard"]` in `settings.json`: command/args come from the theia approval.
  6. Same entry's `registryMetadata.configHash` is the theia approval's hash, not eclipsesource's.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
