### PR TITLE
fix(ai-registry): route AI settings links through the AI settings command

### DIFF
--- a/packages/ai-ide/src/common/command-prompt-template.ts
+++ b/packages/ai-ide/src/common/command-prompt-template.ts
@@ -51,7 +51,7 @@ when the user want to pass arguments to the command.
 {
     "type": "theia-command",
     "commandId": "preferences:open",
-    "arguments": ["ai-features"]
+    "arguments": ["editor.fontSize"]
 }
 \`\`\`
 

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.spec.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.spec.ts
@@ -27,6 +27,7 @@ try {
 
 import { expect } from 'chai';
 import { ILogger, MessageService, PreferenceService } from '@theia/core';
+import { AI_SHOW_SETTINGS_COMMAND } from '@theia/ai-core/lib/browser/ai-core-command-contribution';
 import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { AUTO_UPDATE_OVERRIDES_PREF, AUTO_UPDATE_PREF, AutoUpdateMode } from '../../common/ai-registry-preferences';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
@@ -455,6 +456,27 @@ describe('RegistryAutoUpdateService', () => {
             await service.check();
             expect(service.attempted).to.be.empty;
             expect(policy.getMode('skill', skillEntry.skillId)).to.equal('ask');
+        });
+    });
+
+    describe('settings link', () => {
+
+        /** Exposes the real link builder, which {@link TestAutoUpdateService} replaces with a placeholder. */
+        class LinkAutoUpdateService extends RegistryAutoUpdateService {
+            link(): string {
+                return this.settingsLink();
+            }
+        }
+
+        it('targets the AI settings command, since AI preferences have no row in the Settings UI', () => {
+            const link = new LinkAutoUpdateService().link();
+            expect(link).to.contain(`command:${AI_SHOW_SETTINGS_COMMAND.id}`);
+            expect(link).to.not.contain('preferences:open');
+        });
+
+        it('deep-links to the auto-update preference', () => {
+            const link = new LinkAutoUpdateService().link();
+            expect(link).to.contain(encodeURIComponent(JSON.stringify([AUTO_UPDATE_PREF])));
         });
     });
 

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { CommandService, ILogger, MessageService, nls } from '@theia/core';
-import { CommonCommands } from '@theia/core/lib/browser/common-commands';
+import { AI_SHOW_SETTINGS_COMMAND } from '@theia/ai-core/lib/browser';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { VSXExtensionsCommands } from '@theia/vsx-registry/lib/browser/vsx-extension-commands';
 import { AUTO_UPDATE_PREF, AutoUpdateMode, RegistryArtifactKind } from '../../common/ai-registry-preferences';
@@ -305,9 +305,15 @@ export class RegistryAutoUpdateService {
      * Markdown link opening the default preference. Notification messages are rendered as
      * inline markdown and their links are opened through the `OpenerService`, where core's
      * `CommandOpenHandler` picks up the `command:` scheme.
+     *
+     * Routed through {@link AI_SHOW_SETTINGS_COMMAND} rather than `preferences:open`, because
+     * `ai-features.*` preferences are hidden from the Settings UI once the AI Configuration view
+     * covers them; a `preferences:open` link would open Settings filtered on a preference that has
+     * no row there. The command lands on the AI Configuration view where `@theia/ai-ide` is
+     * present and falls back to the Settings UI where it is not.
      */
     protected settingsLink(): string {
         const args = encodeURIComponent(JSON.stringify([AUTO_UPDATE_PREF]));
-        return `[${nls.localizeByDefault('Settings')}](command:${CommonCommands.OPEN_PREFERENCES.id}?${args})`;
+        return `[${nls.localize('theia/ai-registry/autoUpdate/aiSettings', 'AI Settings')}](command:${AI_SHOW_SETTINGS_COMMAND.id}?${args})`;
     }
 }


### PR DESCRIPTION
#### What it does

Fixes #17999.

`ai-features.*` preferences are hidden from the Settings UI (`HideAiPreferencesContribution`), and `PreferenceTreeGenerator` skips hidden properties — so a `preferences:open` link deep-linking to one opens an empty Settings editor.

- `RegistryAutoUpdateService.settingsLink()` now targets `AI_SHOW_SETTINGS_COMMAND` instead of `preferences:open`. `@theia/ai-ide` overrides that command to open the AI Configuration view (where General's catch-all renders the preference under "Registry"); apps without it keep the Settings UI fallback. Link text changed from "Settings" to "AI Settings" to match where it lands.
- The Command agent's prompt example no longer passes `ai-features` to `preferences:open`, so it stops teaching the model the same stale route. The example's purpose is to show argument syntax, which `editor.fontSize` demonstrates just as well.

#### How to test

1. Install a skill / MCP server / Agent Plugin from the AI registry that has an available update, with `ai-features.registry.autoUpdate` set to `ask`.
2. Reload the window and click **AI Settings** in the update notification.
3. The AI Configuration view opens on General, scrolled to and flashing the `ai-features.registry.autoUpdate` row.

Unit tests cover the link target: `npx lerna run test --scope @theia/ai-registry`. The existing test harness stubbed out the hint methods, so the real link builder had no coverage — two cases added.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
