### PR TITLE
fix(core): align icon and label in viewsWelcome buttons

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -219,10 +219,17 @@
   padding: 0 var(--theia-ui-padding);
 }
 
+/* Centered as a flex line rather than by text alignment: a codicon is a 16px
+   inline-block on the same baseline as the 13px label, so in normal flow it
+   rides above the text and stretches the line box. */
 .theia-TreeContainer .theia-WelcomeView .theia-WelcomeViewButton {
   width: 100%;
   max-width: var(--theia-welcomeView-button-maxWidth);
   margin: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: calc(var(--theia-ui-padding) / 2);
 }
 
 .theia-TreeContainer .theia-WelcomeView .theia-WelcomeViewCommandLink {


### PR DESCRIPTION
#### What it does

A `viewsWelcome` button centers its contents by text alignment. Since #17690 those contents can include a codicon, which is a 16px `inline-block` sharing the 13px label's baseline — so the icon rides above the text, and the line box it enlarges pushes the text below the button's center. Neither ends up centered.

| Before | After |
| --- | --- |
| <img width="434" alt="welcome buttons before" src="https://raw.githubusercontent.com/dr14-make/theia/0a9778d9511c1dcd8aeecba8c3940860f6610941/welcome-before.png"> | <img width="434" alt="welcome buttons after" src="https://raw.githubusercontent.com/dr14-make/theia/0a9778d9511c1dcd8aeecba8c3940860f6610941/welcome-after.png"> |

Four cases in one view: two icon labels, one without an icon, and one icon label long enough to wrap.

This centers the contents as a flex line. `align-items: center` puts icon and label on a shared center; the `gap` replaces the leading space in a `$(icon) Label` string, which is dropped once each segment is a flex item.

It is the shape Theia already uses for the same icon-plus-label problem in `#theia-statusBar .area .element`, and the one VS Code uses for the equivalent widget (`.monaco-text-button`).

Vertical centers for `$(robot) Launch AI Agent`, in px: icon 554.5, label 558.0, button 556.0 before — all three 554.5 after. The button also drops from 31px to 28px, no longer 4px taller than an icon-less one.

A label with no icon is unaffected. A wrapping label centers its icon against the whole block, as in VS Code.

#### How to test

1. Use a plugin whose `viewsWelcome` content has a button label with a codicon, e.g. `[$(robot) Launch AI Agent](command:my.command)`, and one without.
2. Open the view so the welcome content shows, and compare against the screenshots above.
3. Narrow the view until a label wraps: the icon stays centered on the label block rather than nudging the first line off center.

The screenshots come from the JuliaComputing Dyad Studio extension's `Actions` view, whose welcome buttons are labelled `$(robot) Launch AI Agent` and `$(package) Import Library`.

#### Follow-ups

Codicons in welcome *text* and *link* labels remain baseline-aligned, which is the right default inside a paragraph — `.theia-hover .codicon` uses `vertical-align: middle` for that case. Not changed here.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service — N/A, CSS only.

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

---

> _Disclaimer: this change was generated with AI assistance, but reviewed, guided, and validated by me. I take full responsibility for its correctness and for it meeting the project's standards._
