### PR TITLE
fix(monaco): keep the tokenizer state when a line exceeds the line limit

### DIFF
--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.spec.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.spec.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2026 Matthew Farrow and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { IGrammar, StateStack } from 'vscode-textmate';
+import { createTextmateTokenizer, TokenizerState } from './textmate-tokenizer';
+
+describe('createTextmateTokenizer', () => {
+
+    // A grammar that hands back the rule stack it was given, so the tests only observe
+    // what the tokenizer itself does with the state.
+    const grammar = <IGrammar><unknown>{
+        tokenizeLine: (line: string, ruleStack: StateStack) => ({ tokens: [], ruleStack }),
+        tokenizeLine2: (line: string, ruleStack: StateStack) => ({ tokens: new Uint32Array(), ruleStack })
+    };
+
+    const tokenizer = createTextmateTokenizer(grammar, { lineLimit: 8 });
+    const longLine = 'x'.repeat(16);
+
+    // Monaco stores the end state and passes it into the next line. Returning anything
+    // other than a `TokenizerState` breaks the line after the skipped one: a short line
+    // silently restarts the grammar, and a second skipped line returns `undefined`,
+    // which Monaco rejects with 'Cannot set null/undefined state', stopping tokenization
+    // for the whole model.
+    it('should keep the state when tokenizeEncoded skips a line over the limit', () => {
+        const state = tokenizer.getInitialState();
+        const { endState } = tokenizer.tokenizeEncoded(longLine, state);
+        expect(endState).to.be.an.instanceOf(TokenizerState);
+        expect(endState).to.equal(state);
+    });
+
+    it('should keep the state when tokenize skips a line over the limit', () => {
+        const state = tokenizer.getInitialState();
+        const { endState } = tokenizer.tokenize(longLine, state);
+        expect(endState).to.be.an.instanceOf(TokenizerState);
+        expect(endState).to.equal(state);
+    });
+
+    it('should tokenize the line after a skipped one from the same state', () => {
+        const initial = tokenizer.getInitialState();
+        const afterSkipped = tokenizer.tokenizeEncoded(longLine, initial).endState;
+        // Two skipped lines in a row is where the broken state surfaced as an exception.
+        const afterSecondSkipped = tokenizer.tokenizeEncoded(longLine, afterSkipped).endState;
+        expect(afterSecondSkipped).to.be.an.instanceOf(TokenizerState);
+        const { endState } = tokenizer.tokenizeEncoded('short', afterSecondSkipped);
+        expect(endState).to.be.an.instanceOf(TokenizerState);
+        expect((<TokenizerState>endState).stateStack).to.equal((<TokenizerState>initial).stateStack);
+    });
+
+});

--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
@@ -57,8 +57,10 @@ export function createTextmateTokenizer(grammar: IGrammar, options: TokenizerOpt
         getInitialState: () => new TokenizerState(INITIAL),
         tokenizeEncoded(line: string, state: TokenizerState): monaco.languages.IEncodedLineTokens {
             if (options.lineLimit !== undefined && line.length > options.lineLimit) {
-                // Skip tokenizing the line if it exceeds the line limit.
-                return { endState: state.stateStack, tokens: new Uint32Array() };
+                // Skip tokenizing the line if it exceeds the line limit. The state must be
+                // handed back as-is: `state.stateStack` is the raw `vscode-textmate` stack, and
+                // Monaco passes whatever is returned here straight into the next line.
+                return { endState: state, tokens: new Uint32Array() };
             }
             const result = grammar.tokenizeLine2(line, state.stateStack, 500);
             return {
@@ -68,8 +70,8 @@ export function createTextmateTokenizer(grammar: IGrammar, options: TokenizerOpt
         },
         tokenize(line: string, state: TokenizerState): monaco.languages.ILineTokens {
             if (options.lineLimit !== undefined && line.length > options.lineLimit) {
-                // Skip tokenizing the line if it exceeds the line limit.
-                return { endState: state.stateStack, tokens: [] };
+                // Skip tokenizing the line if it exceeds the line limit. See `tokenizeEncoded`.
+                return { endState: state, tokens: [] };
             }
             const result = grammar.tokenizeLine(line, state.stateStack, 500);
             return {


### PR DESCRIPTION
#### What it does

Fixes #18006.

`createTextmateTokenizer` returned `state.stateStack` — the raw `vscode-textmate`
stack — instead of the `TokenizerState` Monaco handed it, on the path that skips a
line longer than `editor.maxTokenizationLineLength`. It typechecks only because
`StateStack` also happens to have `clone` and `equals`, so it is structurally
assignable to `monaco.languages.IState`.

Monaco passes that end state into the next line, where reading `.stateStack` off the
raw stack yields `undefined`:

- **short next line** — `grammar.tokenizeLine2(line, undefined, 500)` quietly restarts
  the grammar from its initial state, so the rest of the file is tokenized in the
  wrong context. Silent, no error.
- **next line also over the limit** — `undefined` is returned as the end state,
  `setEndState` rejects it with `Cannot set null/undefined state`, and
  `updateTokensUntilLine` throws. Tokenization stops for the **whole model**, so even
  the short lines above the long ones lose their colors.

The result looks exactly like a missing or broken grammar, which is what makes it
expensive to track down.

Both `tokenizeEncoded` and `tokenize` now return the state they were given.

#### How to test

Automated: `packages/monaco/src/browser/textmate/textmate-tokenizer.spec.ts` is new
and covers all three cases. It fails on `master` (3 failing, the first two with
`expected b{ parent: null, ruleId: +0, … } to be an instance of TokenizerState`) and
passes with this change.

By hand:

1. Set `editor.maxTokenizationLineLength` to `500` (the stock default is 20000, which
   works too if you make the lines longer than that).
2. Open a JSON file with two adjacent lines over the limit:

```json
{
  "a": "b",
  "y": "xxxxx…600 characters…xxxxx",
  "z": "xxxxx…600 characters…xxxxx"
}
```

3. Before: nothing in the file is colored and the console carries
   `Cannot set null/undefined state`. After: line 2 is colored normally and only the
   two over-length lines go untokenized. A file with a *single* long line behaves the
   same before and after, which is why this hides so well.

I found this downstream in the Arduino IDE (which sets the limit to 500), where three
real project files rendered black. Verified there against the built app by forcing
full tokenization on every open model and reading back the token classes: all three
files tokenize with the fix, the two-adjacent-long-lines control no longer throws, and
other languages in the same window are unchanged.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
