### PR TITLE
fix(plugin-ext): ignore dotfiles when resolving a local plugin directory

### DIFF
--- a/packages/plugin-ext/src/main/node/resolvers/local-directory-plugin-deployer-resolver.ts
+++ b/packages/plugin-ext/src/main/node/resolvers/local-directory-plugin-deployer-resolver.ts
@@ -30,8 +30,12 @@ export class LocalDirectoryPluginDeployerResolver extends LocalPluginDeployerRes
 
     protected async resolveFromLocalPath(pluginResolverContext: PluginDeployerResolverContext, localPath: string): Promise<void> {
         const files = await fs.readdir(localPath);
-        files.forEach(file =>
-            pluginResolverContext.addPlugin(file, path.resolve(localPath, file))
-        );
+        files.forEach(file => {
+            if (file.startsWith('.')) {
+                // Not a plugin, e.g. the `.DS_Store` the macOS Finder drops into any folder it displays.
+                return;
+            }
+            pluginResolverContext.addPlugin(file, path.resolve(localPath, file));
+        });
     }
 }


### PR DESCRIPTION
#### What it does

Fixes #18007.

`LocalDirectoryPluginDeployerResolver.resolveFromLocalPath` added every entry of the
directory as a plugin. On macOS the Finder drops a `.DS_Store` into any folder the
user has looked at, so the deployer then tried to read `.DS_Store/package.json` and
logged this on **every** start:

```
root ERROR Failed to load plugin dependencies from '/Users/…/plugins/.DS_Store': Error: ENOTDIR: not a directory, open '/Users/…/plugins/.DS_Store/package.json'
```

The real plugins still deploy, so it is only noise — but it is permanent noise that
sends people looking for a broken plugin that does not exist. The same happens for any
other stray dotfile, such as the `._*` AppleDouble files left by a copy from a non-HFS
volume.

A plugin directory never begins with a dot, so dot-prefixed entries are skipped.

#### How to test

1. Point the app at a local plugin directory, e.g. `THEIA_PLUGINS=local-dir:/path/to/plugins`.
2. `touch /path/to/plugins/.DS_Store` (or just open the folder in Finder once).
3. Start the app and read the backend log.

Before: `Failed to load plugin dependencies … ENOTDIR`, once per dotfile, on every
start. After: no error, and the plugins in that directory deploy as before.

This is the same fix we have been carrying downstream in the Arduino IDE as a subclass
override.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
