### PR TITLE
fix(ai-chat-ui): keep chat input cursor visible on wrapped lines

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-scroll-util.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-scroll-util.spec.ts
@@ -1,0 +1,42 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { computeRevealScrollDelta } from './chat-input-scroll-util';
+
+describe('computeRevealScrollDelta', () => {
+    const viewportHeight = 240;
+
+    it('returns 0 when the row is fully visible', () => {
+        expect(computeRevealScrollDelta(100, 120, viewportHeight)).to.equal(0);
+    });
+
+    it('returns 0 when the row touches the bottom edge', () => {
+        expect(computeRevealScrollDelta(220, 240, viewportHeight)).to.equal(0);
+    });
+
+    it('scrolls up by the overshoot when the row is above the viewport', () => {
+        expect(computeRevealScrollDelta(-346, -326, viewportHeight)).to.equal(-346);
+    });
+
+    it('scrolls down by the overshoot when the row is below the viewport', () => {
+        expect(computeRevealScrollDelta(560, 580, viewportHeight)).to.equal(340);
+    });
+
+    it('scrolls down when the row is only partially below the viewport', () => {
+        expect(computeRevealScrollDelta(230, 250, viewportHeight)).to.equal(10);
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-input-scroll-util.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-scroll-util.ts
@@ -1,0 +1,30 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Computes how far a scroll container must scroll so that the vertical range `[rowTop, rowBottom]`,
+ * given in pixels relative to the top edge of the container's visible area, becomes fully visible.
+ * Negative values scroll up, positive values scroll down, `0` means the range is already visible.
+ */
+export function computeRevealScrollDelta(rowTop: number, rowBottom: number, viewportHeight: number): number {
+    if (rowTop < 0) {
+        return rowTop;
+    }
+    if (rowBottom > viewportHeight) {
+        return rowBottom - viewportHeight;
+    }
+    return 0;
+}

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -39,15 +39,15 @@ import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { inject, injectable, optional, postConstruct, named } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
-import { IMouseEvent, Range } from '@theia/monaco-editor-core';
+import { IMouseEvent, IPosition } from '@theia/monaco-editor-core';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { SimpleMonacoEditor } from '@theia/monaco/lib/browser/simple-monaco-editor';
 import { ChangeSetActionRenderer, ChangeSetActionService } from './change-set-actions/change-set-action-service';
 import { ChatInputAgentSuggestions } from './chat-input-agent-suggestions';
+import { computeRevealScrollDelta } from './chat-input-scroll-util';
 import { CHAT_VIEW_LANGUAGE_EXTENSION } from './chat-view-language-contribution';
 import { ContextVariablePicker } from './context-variable-picker';
 import { TASK_CONTEXT_VARIABLE } from '@theia/ai-chat/lib/browser/task-context-variable';
-import { IModelDeltaDecoration } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
 import { EditorOption } from '@theia/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 import { SuggestController } from '@theia/monaco-editor-core/esm/vs/editor/contrib/suggest/browser/suggestController';
 import { ChatInputHistoryService, ChatInputNavigationState } from './chat-input-history';
@@ -2074,37 +2074,26 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                 props.contextMenuCallback(e.event)
             );
 
-            const updateLineCounts = () => {
-                // We need the line numbers to allow scrolling by using the keyboard
-                const model = editor.getControl().getModel()!;
-                const lineCount = model.getLineCount();
-                const decorations: IModelDeltaDecoration[] = [];
-
-                for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
-                    decorations.push({
-                        range: new Range(lineNumber, 1, lineNumber, 1),
-                        options: {
-                            description: `line-number-${lineNumber}`,
-                            isWholeLine: false,
-                            className: `line-number-${lineNumber}`,
-                        }
-                    });
+            // The editor is laid out at its full content height and the surrounding container
+            // scrolls, so Monaco cannot reveal the cursor itself. Scroll the container to the
+            // visual row of the cursor; for wrapped lines this differs from the start of the model line.
+            const revealCursor = (position: IPosition) => {
+                const container = editorContainerRef.current;
+                const control = editor.getControl();
+                const editorNode = control.getDomNode();
+                if (!container || !editorNode) {
+                    return;
                 }
-
-                const lineNumbers = model.getAllDecorations().filter(predicate => predicate.options.description?.startsWith('line-number-'));
-                editor.getControl().removeDecorations(lineNumbers.map(d => d.id));
-                editor.getControl().createDecorationsCollection(decorations);
+                const rowTop = editorNode.getBoundingClientRect().top - container.getBoundingClientRect().top
+                    + control.getTopForPosition(position.lineNumber, position.column);
+                const rowBottom = rowTop + control.getOption(EditorOption.lineHeight);
+                const delta = computeRevealScrollDelta(rowTop, rowBottom, container.clientHeight);
+                if (delta !== 0) {
+                    container.scrollTop += delta;
+                }
             };
 
-            editor.getControl().getModel()?.onDidChangeContent(() => {
-                updateLineCounts();
-            });
-
-            editor.getControl().onDidChangeCursorPosition(e => {
-                const lineNumber = e.position.lineNumber;
-                const line = editor.getControl().getDomNode()?.querySelector(`.line-number-${lineNumber}`);
-                line?.scrollIntoView({ behavior: 'instant', block: 'nearest' });
-            });
+            editor.getControl().onDidChangeCursorPosition(e => revealCursor(e.position));
 
             editorRef.current = editor;
             props.setEditorRef(editor);
@@ -2112,8 +2101,6 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
             if (props.initialValue) {
                 setValue(props.initialValue);
             }
-
-            updateLineCounts();
         };
         createInputElement();
 


### PR DESCRIPTION
#### What it does

Closes #18012

The chat input followed the cursor by scrolling a zero-width `line-number-<n>` decoration at column 1 of the model line into view. With word wrap that is the first visual row of the line, so once a line wrapped past the input's max height every keystroke scrolled the cursor out of view.

The container is now scrolled to the cursor's visual row, computed with `getTopForPosition`, which accounts for wrapping. The per-line decorations (recreated on every keystroke) are removed. The scroll math is in `chat-input-scroll-util.ts` with unit tests.

#### How to test

1. Open the AI Chat view and focus the input.
2. Without pressing Enter, type until the text wraps to more than 12 visual lines, then keep typing: the cursor stays visible (before: the input jumped to the top of the line on every keystroke).
3. Scroll the input to the top and type a character: it scrolls back to the cursor.
4. Move the cursor with ArrowUp/ArrowDown beyond the visible rows: the input follows the cursor. The Ask AI inline input uses the same component.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
