### PR TITLE
fix(collaboration): apply remote Yjs deltas against pre-edit offsets

### DIFF
--- a/packages/collaboration/src/browser/collaboration-instance.ts
+++ b/packages/collaboration/src/browser/collaboration-instance.ts
@@ -39,6 +39,7 @@ import { FileChange, FileChangeType, FileOperation } from '@theia/filesystem/lib
 import { OpenCollaborationYjsProvider } from 'open-collaboration-yjs';
 import { createMutex } from 'lib0/mutex';
 import { CollaborationUtils } from './collaboration-utils';
+import { yTextDeltaToEdits } from './yjs-delta';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
 export const CollaborationInstanceFactory = Symbol('CollaborationInstanceFactory');
@@ -735,23 +736,15 @@ export class CollaborationInstance implements Disposable {
             this.yjsMutex(() => {
                 updating = true;
                 try {
-                    let index = 0;
-                    const operations: { range: MonacoRange, text: string }[] = [];
-                    textEvent.delta.forEach(delta => {
-                        if (delta.retain !== undefined) {
-                            index += delta.retain;
-                        } else if (delta.insert !== undefined) {
-                            const pos = model.textEditorModel.getPositionAt(index);
-                            const range = new MonacoRange(pos.lineNumber, pos.column, pos.lineNumber, pos.column);
-                            const insert = delta.insert as string;
-                            operations.push({ range, text: insert });
-                            index += insert.length;
-                        } else if (delta.delete !== undefined) {
-                            const pos = model.textEditorModel.getPositionAt(index);
-                            const endPos = model.textEditorModel.getPositionAt(index + delta.delete);
-                            const range = new MonacoRange(pos.lineNumber, pos.column, endPos.lineNumber, endPos.column);
-                            operations.push({ range, text: '' });
-                        }
+                    const operations = yTextDeltaToEdits(textEvent.delta).map(edit => {
+                        const startPos = model.textEditorModel.getPositionAt(edit.start);
+                        const endPos = edit.end === edit.start
+                            ? startPos
+                            : model.textEditorModel.getPositionAt(edit.end);
+                        return {
+                            range: new MonacoRange(startPos.lineNumber, startPos.column, endPos.lineNumber, endPos.column),
+                            text: edit.text
+                        };
                     });
                     this.pushChangesToModel(model, operations);
                 } catch (err) {

--- a/packages/collaboration/src/browser/yjs-delta.spec.ts
+++ b/packages/collaboration/src/browser/yjs-delta.spec.ts
@@ -1,0 +1,57 @@
+// *****************************************************************************
+// Copyright (C) 2026 Sahil Gupta and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { yTextDeltaToEdits } from './yjs-delta';
+
+describe('yTextDeltaToEdits', () => {
+
+    it('returns no edits for a pure retain', () => {
+        expect(yTextDeltaToEdits([{ retain: 10 }])).to.deep.equal([]);
+    });
+
+    it('places an insert at the retained offset without advancing the pre-edit cursor', () => {
+        // retain 5, insert 'abc', delete 2: the delete must still address old offsets [5, 7).
+        expect(yTextDeltaToEdits([{ retain: 5 }, { insert: 'abc' }, { delete: 2 }])).to.deep.equal([
+            { start: 5, end: 5, text: 'abc' },
+            { start: 5, end: 7, text: '' }
+        ]);
+    });
+
+    it('advances past a delete so a following insert stays aligned to the old document', () => {
+        // delete 3 then insert 'x': the insert lands at old offset 3, not 0.
+        expect(yTextDeltaToEdits([{ delete: 3 }, { insert: 'x' }])).to.deep.equal([
+            { start: 0, end: 3, text: '' },
+            { start: 3, end: 3, text: 'x' }
+        ]);
+    });
+
+    it('keeps multiple changes aligned across retains, inserts and deletes', () => {
+        // cursor over the old document: 0 ->2 (retain) ->3 (delete 1) ->6 (retain 3) ->6 (insert) ->8 (delete 2)
+        expect(yTextDeltaToEdits([
+            { retain: 2 }, { delete: 1 }, { retain: 3 }, { insert: 'zz' }, { delete: 2 }
+        ])).to.deep.equal([
+            { start: 2, end: 3, text: '' },
+            { start: 6, end: 6, text: 'zz' },
+            { start: 6, end: 8, text: '' }
+        ]);
+    });
+
+    it('skips non-string (embed) inserts', () => {
+        expect(yTextDeltaToEdits([{ retain: 1 }, { insert: { embed: true } }, { retain: 1 }])).to.deep.equal([]);
+    });
+
+});

--- a/packages/collaboration/src/browser/yjs-delta.ts
+++ b/packages/collaboration/src/browser/yjs-delta.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2026 Sahil Gupta and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * A single operation of a Yjs text delta, as delivered by `Y.YTextEvent.delta`.
+ */
+export interface YTextDeltaOp {
+    retain?: number;
+    insert?: string | object;
+    delete?: number;
+}
+
+/**
+ * An edit expressed as offsets into the pre-edit document.
+ */
+export interface YjsDeltaEdit {
+    /** Start offset into the pre-edit document. */
+    start: number;
+    /** End offset into the pre-edit document; equal to `start` for a pure insertion. */
+    end: number;
+    /** Replacement text; empty for a pure deletion. */
+    text: string;
+}
+
+/**
+ * Converts a Yjs text delta into edits addressed against the pre-edit document.
+ *
+ * A Yjs delta walks two cursors at once: `retain` advances in both the old and the new
+ * document, `insert` advances only in the new one, and `delete` advances only in the old
+ * one. The edits produced here are collected and applied together against the pre-edit
+ * model, so every offset must address that same, unchanged document. The cursor therefore
+ * advances on `retain` and `delete` and stands still on `insert`.
+ *
+ * Non-string inserts (embeds) carry no text for a plain text model and are skipped.
+ */
+export function yTextDeltaToEdits(delta: readonly YTextDeltaOp[]): YjsDeltaEdit[] {
+    let index = 0;
+    const edits: YjsDeltaEdit[] = [];
+    for (const op of delta) {
+        if (op.retain !== undefined) {
+            index += op.retain;
+        } else if (op.insert !== undefined) {
+            if (typeof op.insert === 'string') {
+                edits.push({ start: index, end: index, text: op.insert });
+            }
+            // No index advance: an insert adds characters to the new document only.
+        } else if (op.delete !== undefined) {
+            edits.push({ start: index, end: index + op.delete, text: '' });
+            index += op.delete;
+        }
+    }
+    return edits;
+}


### PR DESCRIPTION
#### What it does

Closes #17998

The `Y.YTextEvent` observer in `registerModelUpdate` collects Monaco edit operations and applies them together through `pushChangesToModel`, so every `getPositionAt` addresses the pre-edit document. A Yjs delta walks two cursors: `retain` advances in both documents, `insert` only in the new one, `delete` only in the old one. Since the offsets are resolved against the old document, the cursor must advance on `retain` and `delete` and stand still on `insert`.

The previous code did the opposite (advanced on `insert`, stood still on `delete`), so every change after the first insert or delete in a multi-change delta was displaced. That produces overlapping ranges, which `pushEditOperations` rejects and `pushChangesToModel` swallows, leaving the model silently unmodified. Once the model is stale, the next local keystroke is encoded from stale offsets and the 200 ms resync propagates the damage to every peer, dropping text with no visible conflict. Single-change deltas are unaffected, which is why it only surfaces under concurrent editing of the same line.

The offset walk is extracted into `yTextDeltaToEdits` so the arithmetic is unit tested independently of Monaco. The observer maps the resulting offsets to `MonacoRange`s as before.

Reported by @daviwil in #17998 with a precise root-cause analysis.

#### How to test

Automated:

- `npx lerna run test --scope @theia/collaboration`. The new `yjs-delta.spec.ts` covers `retain`, `insert` and `delete` alignment, multi-change deltas, and embed inserts. The multi-change cases fail without this change.

Manual:

1. Open the same document in two connected peers.
2. Concurrently edit the same line so that a single remote delta carries more than one change, for example an insertion near the start of the line and a deletion later on the same line.
3. Confirm both editors converge on the same content, and that the console shows no `pushEditOperations` range errors.

#### Follow-ups

- `pushChangesToModel` catches the `pushEditOperations` failure and only logs it. That is what made this bug silent rather than visible. Whether such a failure should surface to the user is a separate discussion and is not changed here.
- The observer still resolves each offset individually through `getPositionAt`. If this ever shows up as hot for very large deltas, the conversion could walk the line starts once instead. Not addressed here, as it is unrelated to the correctness fix.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
